### PR TITLE
Fixing max upload size info in Account section

### DIFF
--- a/templates/form-fields/file-field.php
+++ b/templates/form-fields/file-field.php
@@ -65,6 +65,6 @@ if ( ! empty( $data->ajax ) && wpum_user_can_upload_file_via_ajax() ) {
 		<?php echo $data->description; ?>
 	<?php endif ?>
 
-	<?php printf( __( 'Maximum file size: %s.', 'wp-user-manager' ), wpum_max_upload_size( '', $file_size ) ); ?>
+	<?php printf( __( 'Maximum file size: %s.', 'wp-user-manager' ), wpum_max_upload_size( isset( $data->key ) ? $data->key : '', $file_size ) ); ?>
 
 </small>


### PR DESCRIPTION
wpum_max_upload_size was not getting field key to output proper info of size restrictions.