### PR TITLE
Changed loading behavior of WP User manager

### DIFF
--- a/wp-user-manager.php
+++ b/wp-user-manager.php
@@ -479,4 +479,4 @@ function WPUM() {
 	return WP_User_Manager::instance();
 }
 
-WPUM();
+add_action( 'plugins_loaded', 'WPUM' );


### PR DESCRIPTION
This is done to allow overwriting thing like Carbon Fields without a must use plugin. As requested in https://github.com/WPUserManager/wp-user-manager/issues/164