### PR TITLE
#184 allow using recovery url registration email

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -390,7 +390,7 @@ function wpum_log_user_in( $email_or_id ) {
  * @param mixed $psw
  * @return void
  */
-function wpum_send_registration_confirmation_email( $user_id, $psw = false ) {
+function wpum_send_registration_confirmation_email( $user_id, $psw = false, $password_reset_key = false ) {
 
 	$registration_confirmation_email = wpum_get_email( 'registration_confirmation', $user_id );
 
@@ -419,6 +419,10 @@ function wpum_send_registration_confirmation_email( $user_id, $psw = false ) {
 
 			if ( ! empty( $psw ) ) {
 				$emails->__set( 'plain_text_password', $psw );
+			}
+
+			if ( $password_reset_key ){
+				$emails->__set( 'password_reset_key', $password_reset_key );
 			}
 
 			$email   = $user->data->user_email;
@@ -1326,6 +1330,7 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) {
 	 * @return void
 	 */
 	function wp_new_user_notification( $user_id, $plaintext_pass = '' ) {
+
 		$password_set_by_admin = false;
 		if ( isset( $_POST['pass1-text'] ) ) {
 			$password_set_by_admin = $_POST['pass1-text'];
@@ -1341,7 +1346,10 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) {
 			wp_set_password( $password, $user_id );
 		}
 
-		wpum_send_registration_confirmation_email( $user_id, $password );
+		$user = get_user_by('id', $user_id);
+		$password_reset_key = get_password_reset_key( $user );
+
+		wpum_send_registration_confirmation_email( $user_id, $password, $password_reset_key );
 	}
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1346,7 +1346,7 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) {
 			wp_set_password( $password, $user_id );
 		}
 
-		$user = get_user_by('id', $user_id);
+		$user = get_user_by( 'id', $user_id );
 		$password_reset_key = get_password_reset_key( $user );
 
 		wpum_send_registration_confirmation_email( $user_id, $password, $password_reset_key );

--- a/includes/wpum-forms/class-wpum-form-registration.php
+++ b/includes/wpum-forms/class-wpum-form-registration.php
@@ -554,8 +554,10 @@ class WPUM_Form_Registration extends WPUM_Form {
 			// Allow developers to extend signup process.
 			do_action( 'wpum_before_registration_end', $new_user_id, $values, $form );
 
+			$password_reset_key = get_password_reset_key( $user );
+
 			// Now send a confirmation email to the user.
-			wpum_send_registration_confirmation_email( $new_user_id, $password );
+			wpum_send_registration_confirmation_email( $new_user_id, $password, $password_reset_key );
 
 			// Allow developers to extend signup process.
 			do_action( 'wpum_after_registration', $new_user_id, $values, $form );


### PR DESCRIPTION
@polevaultweb 

This is done.

In order for the reset password link to appear on the confirmation email add this texts in the email configuration
To reset your password, visit the following address:
{recovery_url}