### PR TITLE
File field inside Repeater doesn't display correct max file size

### DIFF
--- a/templates/form-fields/complex-field.php
+++ b/templates/form-fields/complex-field.php
@@ -111,7 +111,8 @@ if( count( $fields ) ){
 				'options'     => $options,
 				'template'    => $field->get_parent_type(),
 				'name'		  => "{$parent_key}[{$index}][{$key}]",
-				'value'		  => $value
+				'value'		  => $value,
+				'max_file_size' => $field->get_meta( 'max_file_size' ),
 			);
 
 			WPUM()->templates


### PR DESCRIPTION
@polevaultweb

Resolves https://github.com/WPUserManager/wpum-custom-fields/issues/51