### PR TITLE
Enable select2 for dropdown fields that have stylized ui enabled

### DIFF
--- a/assets/js/src/wp-user-manager.js
+++ b/assets/js/src/wp-user-manager.js
@@ -11,6 +11,17 @@ jQuery( function( $ ) {
 			$( this ).select2( args );
 		} );
 
+		$('.wpum-select2').each(function () {
+			var args = {
+				theme: 'default'
+			};
+			var placeholder = $(this).attr('placeholder');
+			if (placeholder) {
+				args['placeholder'] = placeholder;
+			}
+			$(this).select2(args);
+		});
+
 		$( '.wpum-datepicker:not([readonly]):not(.wpum-clone-field)' ).flatpickr( {
 			dateFormat: wpumFrontend.dateFormat
 		} );

--- a/assets/js/wp-user-manager.js
+++ b/assets/js/wp-user-manager.js
@@ -14,6 +14,17 @@ jQuery( function( $ ) {
 			$( this ).select2( args );
 		} );
 
+		$('.wpum-select2').each(function () {
+			var args = {
+				theme: 'default'
+			};
+			var placeholder = $(this).attr('placeholder');
+			if (placeholder) {
+				args['placeholder'] = placeholder;
+			}
+			$(this).select2(args);
+		});
+
 		$( '.wpum-datepicker:not([readonly]):not(.wpum-clone-field)' ).flatpickr( {
 			dateFormat: wpumFrontend.dateFormat
 		} );

--- a/templates/form-fields/dropdown-field.php
+++ b/templates/form-fields/dropdown-field.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * The template for displaying the select field.
  *
@@ -13,17 +14,17 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
-if ( ! defined( 'ABSPATH' ) ) exit;
+// Exit if accessed directly
+if (!defined('ABSPATH')) exit;
 
 ?>
 
-<select name="<?php echo esc_attr( isset( $data->name ) ? $data->name : $data->key ); ?>" id="<?php echo esc_attr( $data->key ); ?>" <?php if ( ! empty( $data->required ) ) echo 'required'; ?> <?php if ( ! empty( $data->read_only ) ) echo 'disabled'; ?>>
-	<?php foreach ( $data->options as $key => $value ) : ?>
-		<option value="<?php echo esc_attr( $key ); ?>" <?php if ( isset( $data->value ) || isset( $data->default ) ) selected( isset( $data->value ) ? $data->value : $data->default, $key ); ?>><?php echo esc_html( $value ); ?></option>
+<select name="<?php echo esc_attr(isset($data->name) ? $data->name : $data->key); ?>" id="<?php echo esc_attr($data->key); ?>" <?php if (!empty($data->required)) echo 'required'; ?> <?php if (!empty($data->read_only)) echo 'disabled'; ?> <?php if (!empty($data->ui)) echo 'class="wpum-select2"' ?> placeholder="<?php echo empty($data->placeholder) ? '' : esc_attr($data->placeholder); ?>">
+	<?php foreach ($data->options as $key => $value) : ?>
+		<option value="<?php echo esc_attr($key); ?>" <?php if (isset($data->value) || isset($data->default)) selected(isset($data->value) ? $data->value : $data->default, $key); ?>><?php echo esc_html($value); ?></option>
 	<?php endforeach; ?>
 </select>
-<?php if ( ! empty( $data->read_only ) ) : ?>
-	<input type="hidden" name="<?php echo esc_attr( isset( $data->name ) ? $data->name : $data->key ); ?>" id="<?php echo esc_attr( $data->key ); ?>" value="<?php echo isset( $data->value ) ? esc_attr( $data->value ) : ''; ?>" />
+<?php if (!empty($data->read_only)) : ?>
+	<input type="hidden" name="<?php echo esc_attr(isset($data->name) ? $data->name : $data->key); ?>" id="<?php echo esc_attr($data->key); ?>" value="<?php echo isset($data->value) ? esc_attr($data->value) : ''; ?>" />
 <?php endif; ?>
-<?php if ( ! empty( $data->description ) ) : ?><small class="description"><?php echo $data->description; ?></small><?php endif; ?>
+<?php if (!empty($data->description)) : ?><small class="description"><?php echo $data->description; ?></small><?php endif; ?>


### PR DESCRIPTION
Allows select2 to be enabled for acf single select dropdown fields by enabling the stylized ui option.
I haven't built the min.js files but I can make an additional commit if necessary.
This also requires an additional change in the wpum-acf plugin to work:
/wpum-acf/includes/registration-form.php on line 59 I added an additional value for ui
```
$fields[ $field['key'] ] = array(
	'label'       => $label,
	'type'        => $type,
	'description' => $field['instructions'],
	'required'    => $field['required'],
	'value'       => $default,
	'priority'    => 100 + ( $i * 10 ) + $field['menu_order'],
	'options'     => $options,
	'ui'		  => $field['ui'],
);

```