### PR TITLE
Apostrophe for the field title causes an error and adds a "/" before …

### DIFF
--- a/includes/filters.php
+++ b/includes/filters.php
@@ -329,3 +329,9 @@ function wpum_maybe_display_field( $display, $field = null ) {
 
 	return count( array_intersect( wp_get_current_user()->roles, $field_roles ) ) > 0;
 }
+
+function wpum_removed_slashes_from_fields( $field_name ){
+	return wpum_removed_slashes( $field_name );
+}
+add_filter( 'wpum_get_name', 'wpum_removed_slashes_from_fields' );
+add_filter( 'wpum_get_description', 'wpum_removed_slashes_from_fields' );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1411,9 +1411,9 @@ function wpum_get_display_name_options() {
 }
 
 function wpum_removed_slashes( $content ) {
-    $content = preg_replace( "/\\\+'/", "'", $content );
-    $content = preg_replace( '/\\\+"/', '"', $content );
-    $content = preg_replace( '/\\\+/', '\\', $content );
+	$content = preg_replace( "/\\\+'/", "'", $content );
+	$content = preg_replace( '/\\\+"/', '"', $content );
+	$content = preg_replace( '/\\\+/', '\\', $content );
  
-    return $content;
+	return $content;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1409,3 +1409,11 @@ function wpum_get_display_name_options() {
 		),
 	);
 }
+
+function wpum_removed_slashes( $content ) {
+    $content = preg_replace( "/\\\+'/", "'", $content );
+    $content = preg_replace( '/\\\+"/', '"', $content );
+    $content = preg_replace( '/\\\+/', '\\', $content );
+ 
+    return $content;
+}

--- a/includes/wpum-fields/class-wpum-field.php
+++ b/includes/wpum-fields/class-wpum-field.php
@@ -261,7 +261,7 @@ class WPUM_Field {
 	 * @return void
 	 */
 	public function get_name() {
-		return $this->name;
+		return apply_filters( 'wpum_get_name', $this->name );
 	}
 
 	/**
@@ -279,7 +279,7 @@ class WPUM_Field {
 	 * @return void
 	 */
 	public function get_description() {
-		return $this->description;
+		return apply_filters( 'wpum_get_description', $this->description );
 	}
 
 	/**


### PR DESCRIPTION
Resolves https://github.com/WPUserManager/wpum-custom-fields/issues/65

## Description

This issue occurs to all fields. That is why I made changes on wp-user-manager rather than on the wpum-custom-fields. I added filter on both get_name() and get_description() functions from WPUM_Field class.

## Testing Instructions

1.

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPUserManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPUserManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
