### PR TITLE
Allow admins to select a default avatar image.

### DIFF
--- a/includes/abstracts/class-wpum-form.php
+++ b/includes/abstracts/class-wpum-form.php
@@ -69,14 +69,14 @@ abstract class WPUM_Form {
 	 * Cloning is forbidden.
 	 */
 	public function __clone() {
-		_doing_it_wrong( __FUNCTION__, sprintf('Cloning %s is forbidden.', __CLASS__), '2.1.9' );
+		_doing_it_wrong( __FUNCTION__, sprintf( 'Cloning %s is forbidden.', __CLASS__ ), '2.1.9' );
 	}
 
 	/**
 	 * Unserializes instances of this class is forbidden.
 	 */
 	public function __wakeup() {
-		_doing_it_wrong( __FUNCTION__, sprintf('Unserializes instances of %s is forbidden.', __CLASS__), '2.1.9' );
+		_doing_it_wrong( __FUNCTION__, sprintf( 'Unserializes instances of %s is forbidden.', __CLASS__ ), '2.1.9' );
 	}
 
 	/**

--- a/includes/admin/class-wpum-addons-page.php
+++ b/includes/admin/class-wpum-addons-page.php
@@ -121,7 +121,7 @@ class WPUM_Addons_Page {
 	 * @return array
 	 */
 	public function add_addon_tab( $tabs ) {
-		$tabs['wpum_addons'] = '<img src="' . WPUM_PLUGIN_URL . 'assets/images/logo.svg" alt="WP User Manager" style="width: 15px; margin-right: 10px; vertical-align: text-bottom;">' .  __( 'WP User Manager ', 'wp-user-manager' ) . '<span class="wpum-addons">' . __( 'Addons', 'wp-user-manager' ) . '</span><style>.plugin-install-wpum_addons a.current { border-bottom-color: #016afe; }</style>';
+		$tabs['wpum_addons'] = '<img src="' . WPUM_PLUGIN_URL . 'assets/images/logo.svg" alt="WP User Manager" style="width: 15px; margin-right: 10px; vertical-align: text-bottom;">' . __( 'WP User Manager ', 'wp-user-manager' ) . '<span class="wpum-addons">' . __( 'Addons', 'wp-user-manager' ) . '</span><style>.plugin-install-wpum_addons a.current { border-bottom-color: #016afe; }</style>';
 
 		return $tabs;
 	}

--- a/includes/admin/class-wpum-avatars.php
+++ b/includes/admin/class-wpum-avatars.php
@@ -189,9 +189,16 @@ class WPUM_Avatars {
 		return true;
 	}
 
+	/**
+	 * @param string $url
+	 * @param mixed  $id_or_email
+	 * @param array  $args
+	 *
+	 * @return array|mixed|string|string[]
+	 */
 	public function set_default_avatar( $url, $id_or_email, $args ) {
 		global $pagenow;
-		if ( is_admin() && ( ! isset( $pagenow ) || 'options-discussion.php' !== $pagenow )  ) {
+		if ( is_admin() && ( ! isset( $pagenow ) || 'options-discussion.php' !== $pagenow ) ) {
 			return $url;
 		}
 

--- a/includes/admin/class-wpum-avatars.php
+++ b/includes/admin/class-wpum-avatars.php
@@ -44,7 +44,7 @@ class WPUM_Avatars {
 		}
 
 		if ( false !== wpum_get_option( 'default_avatar' ) ) {
-			add_image_size( 'wpum-avatar', 50, 50, true );
+			add_image_size( 'wpum-avatar', 100, 100, true );
 			add_filter( 'get_avatar_url', array( $this, 'set_default_avatar' ), 10, 3 );
 			add_filter( 'avatar_defaults', function ( $defaults ) {
 				$defaults = array();

--- a/includes/admin/class-wpum-avatars.php
+++ b/includes/admin/class-wpum-avatars.php
@@ -60,7 +60,7 @@ class WPUM_Avatars {
 			add_filter( 'pre_update_option_wpum_settings', function ( $value, $old_value ) {
 				if ( isset( $value['default_avatar'] ) && ( empty( $old_value['default_avatar'] ) || $old_value['default_avatar'] !== $value['default_avatar'] ) ) {
 					$url           = $value['default_avatar'];
-					$attachment_id = attachment_url_to_postid( $value['default_avatar'] );
+					$attachment_id = attachment_url_to_postid( $url );
 					if ( $attachment_id ) {
 						$url = wp_get_attachment_image_url( $attachment_id, 'wpum-avatar' );
 					}

--- a/includes/admin/class-wpum-avatars.php
+++ b/includes/admin/class-wpum-avatars.php
@@ -49,7 +49,7 @@ class WPUM_Avatars {
 			add_filter( 'avatar_defaults', function ( $defaults ) {
 				$defaults = array();
 
-				$defaults['wpum'] = __( 'WP User Manager', 'wp-user-manager' );
+				$defaults['wpum'] = __( 'Set with by WP User Manager.', 'wp-user-manager' ) . sprintf( ' <a href="%s">%s</a>', admin_url( 'users.php?page=wpum-settings#/profiles' ), __( 'Edit' ) );
 
 				return $defaults;
 			} );

--- a/includes/admin/class-wpum-options-panel.php
+++ b/includes/admin/class-wpum-options-panel.php
@@ -375,6 +375,12 @@ class WPUM_Options_Panel {
 					'type' => 'checkbox',
 				),
 				array(
+					'id'   => 'default_avatar',
+					'name' => __( 'Default Avatar', 'wp-user-manager' ),
+					'desc' => __( 'Select a default image to be used for users who don\'t have a custom avatar or Gravatar registered with their email address.', 'wp-user-manager' ),
+					'type' => 'file',
+				),
+				array(
 					'id'   => 'disable_profile_cover',
 					'name' => __( 'Disable Profile Cover Image', 'wp-user-manager' ),
 					'desc' => __( 'Enable this option to prevent users from uploading a custom profile cover image.', 'wp-user-manager' ),


### PR DESCRIPTION
Resolves https://github.com/WPUserManager/wp-user-manager/issues/348

## Description

## Testing Instructions

1.

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPUserManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPUserManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
