### PR TITLE
#357 - Prevent login to site when site is installed in a sub directory should not cause redirect loop

### DIFF
--- a/includes/actions.php
+++ b/includes/actions.php
@@ -423,11 +423,8 @@ function wpum_prevent_entire_site() {
 	$wp_login_locked = wpum_get_option( 'lock_wplogin' );
 	$is_wp_login     = $pagenow && 'wp-login.php' === $pagenow;
 
-	$url_part = filter_input( INPUT_SERVER, 'REQUEST_URI' );
-
-	if ( empty( $url_part ) ) {
-		$url_part = '';
-	}
+	$url_part = basename( $_SERVER['REQUEST_URI'] );
+	$url_part .= '/';
 
 	$url = home_url( $url_part );
 

--- a/includes/actions.php
+++ b/includes/actions.php
@@ -423,12 +423,9 @@ function wpum_prevent_entire_site() {
 	$wp_login_locked = wpum_get_option( 'lock_wplogin' );
 	$is_wp_login     = $pagenow && 'wp-login.php' === $pagenow;
 
-	$url_part = basename( $_SERVER['REQUEST_URI'] );
-	$url_part .= '/';
+	$requested_url = ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI']; // phpcs:ignore
 
-	$url = home_url( $url_part );
-
-	if ( isset( $_SERVER['REQUEST_URI'] ) && $url === $login_page || ( $is_wp_login && ( ! empty( $_GET['wpum_override'] ) || ! $wp_login_locked ) ) ) { // phpcs:ignore
+	if ( $requested_url === $login_page || ( $is_wp_login && ( ! empty( $_GET['wpum_override'] ) || ! $wp_login_locked ) ) ) { // phpcs:ignore
 		return;
 	}
 
@@ -439,7 +436,7 @@ function wpum_prevent_entire_site() {
 	$password_reset_page_id = wpum_get_core_page_id( 'password' );
 	if ( ! empty( $password_reset_page_id ) ) {
 		$password_reset_page = get_permalink( $password_reset_page_id );
-		if ( 0 === strpos( $url, $password_reset_page ) ) {
+		if ( 0 === strpos( $requested_url, $password_reset_page ) ) {
 			return;
 		}
 	}
@@ -449,14 +446,14 @@ function wpum_prevent_entire_site() {
 		$registration_pages[] = get_permalink( wpum_get_core_page_id( 'register' ) );
 
 		foreach ( apply_filters( 'wpum_registration_pages', $registration_pages ) as $registration_page ) {
-			if ( $url === $registration_page ) {
+			if ( $requested_url === $registration_page ) {
 				return;
 			}
 		}
 	}
 
 	foreach ( apply_filters( 'wpum_prevent_entire_site_access_allowed_urls', array() ) as $allowed_url ) {
-		if ( $url === $allowed_url ) {
+		if ( $requested_url === $allowed_url ) {
 			return;
 		}
 	}


### PR DESCRIPTION
Resolves #357 

## Description

## Testing Instructions


Create new WP installation in sub-directory (e.g If your root site is [test.com](http://test.com/), install it in [test.com/wp/](http://test.com/wp/))
Enable Lock Access to wp-login.php
Enable Prevent site access to visitor
Access the new WP site in incognito.

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPUserManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPUserManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
