### PR TITLE
#359 Prevent site access to visitors setting should not prevent the WP REST API from working

### DIFF
--- a/includes/actions.php
+++ b/includes/actions.php
@@ -409,6 +409,10 @@ function wpum_prevent_entire_site() {
 		return;
 	}
 
+	if ( wpum_is_rest_api_request() ) {
+		return;
+	}
+
 	if ( defined( 'WP_CLI' ) && WP_CLI ) {
 		return;
 	}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1386,7 +1386,7 @@ function wpum_strip_slashes( $content ) {
 
 /**
  * Returns true if the request is a REST API request.
- * 
+ *
  * @return bool
  */
 function wpum_is_rest_api_request() {
@@ -1394,8 +1394,7 @@ function wpum_is_rest_api_request() {
 		return false;
 	}
 
-	$rest_prefix         = trailingslashit( rest_get_url_prefix() );
-	$is_rest_api_request = ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix ) );
+	$rest_prefix = trailingslashit( rest_get_url_prefix() );
 
-	return $is_rest_api_request;
+	return ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix ) ); // phpcs:ignore
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1383,3 +1383,19 @@ function wpum_strip_slashes( $content ) {
 
 	return $content;
 }
+
+/**
+ * Returns true if the request is a REST API request.
+ * 
+ * @return bool
+ */
+function wpum_is_rest_api_request() {
+	if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+		return false;
+	}
+
+	$rest_prefix         = trailingslashit( rest_get_url_prefix() );
+	$is_rest_api_request = ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix ) );
+
+	return $is_rest_api_request;
+}


### PR DESCRIPTION
Resolves #359 

## Description

## Testing Instructions

1. Turn on 'Prevent site access to visitors'
2. Hit the rest api like getting all users

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPUserManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPUserManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
