### PR TITLE
Enable the rendering of form actions in WPUM's Elementor widgets.

### DIFF
--- a/includes/integrations/elementor/widgets/class-wpum-elementor-widget.php
+++ b/includes/integrations/elementor/widgets/class-wpum-elementor-widget.php
@@ -108,7 +108,7 @@ abstract class WPUM_Elementor_Widget extends \Elementor\Widget_Base {
 	 */
 	protected function render() {
 		$shortcode = do_shortcode( shortcode_unautop( $this->generate_shortcode_string() ) );
-		$output    = preg_replace( "/<form action=([\"'])(.*?)\"/", '<form action="javascript:void(0);"', $shortcode );
+		$output    = $shortcode;
 		echo $output; // phpcs:ignore
 	}
 

--- a/includes/integrations/elementor/widgets/class-wpum-elementor-widget.php
+++ b/includes/integrations/elementor/widgets/class-wpum-elementor-widget.php
@@ -107,8 +107,10 @@ abstract class WPUM_Elementor_Widget extends \Elementor\Widget_Base {
 	 * Written in PHP and used to generate the final HTML.
 	 */
 	protected function render() {
-		$shortcode = do_shortcode( shortcode_unautop( $this->generate_shortcode_string() ) );
-		$output    = $shortcode;
+		$output = do_shortcode( shortcode_unautop( $this->generate_shortcode_string() ) );
+		if ( is_admin() ) {
+			$output = preg_replace( "/<form action=([\"'])(.*?)\"/", '<form action="javascript:void(0);"', $output );
+		}
 		echo $output; // phpcs:ignore
 	}
 


### PR DESCRIPTION
Resolves #386 

## Description

## Testing Instructions

1. 1.Create a log in page
2. Edit through Elementor
3. Add the Login Form Widget
4. Try to log in

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPUserManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPUserManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
