### PR TITLE
Fix: Display Taxonomy Field data in user profiles

### DIFF
--- a/includes/fields/class-wpum-field.php
+++ b/includes/fields/class-wpum-field.php
@@ -637,7 +637,7 @@ class WPUM_Field {
 					$value = $user->data->user_email;
 					break;
 			}
-		} elseif ( strpos( $this->get_meta( 'user_meta_key' ), 'wpum_' ) === 0 ) {
+		} elseif ( strpos( $this->get_meta( 'user_meta_key' ), 'wpum_' ) === 0 && $this->get_type() !== 'taxonomy' ) {
 			$value = \WPUM\carbon_get_user_meta( $user_id, $this->get_meta( 'user_meta_key' ) );
 		} else {
 			$value = get_user_meta( $user_id, $this->get_meta( 'user_meta_key' ), true );


### PR DESCRIPTION
Resolves [#](https://github.com/WPUserManager/wpum-custom-fields/issues/85)

## Description
The issue is `\WPUM\carbon_get_user_meta` returns empty for taxonomy field.

## Testing Instructions

1. Create a custom taxonomy and a taxonomy field by following the guide at https://wpusermanager.com/article/268-taxonomy-field/.
2. Choose the checkbox field type.
3. During user registration, ensure that the custom taxonomy is selected.
4. Observe that the data does not appear in the user's profile.

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPUserManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPUserManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
