### PR TITLE
Removed text sanitization on password field.

### DIFF
--- a/includes/emails/wpum-email-functions.php
+++ b/includes/emails/wpum-email-functions.php
@@ -153,7 +153,7 @@ function wpum_email_tag_login_page_url( $user_id = false ) {
  * @return string
  */
 function wpum_email_tag_password( $user_id = false, $password_reset_key = false, $plain_text_password = '' ) {
-	return sanitize_text_field( $plain_text_password );
+	return $plain_text_password;
 }
 
 /**

--- a/includes/fields/types/class-wpum-field-password.php
+++ b/includes/fields/types/class-wpum-field-password.php
@@ -53,4 +53,14 @@ class WPUM_Field_Password extends WPUM_Field_Type {
 		);
 	}
 
+	/**
+	 * Gets the value of a posted field.
+	 *
+	 * @param  string $key
+	 * @param  array  $field
+	 * @return string|array
+	 */
+	public function get_posted_field( $key, $field ) {
+		return filter_input( INPUT_POST, $key );
+	}
 }


### PR DESCRIPTION
Resolves #384 

## Description
The "sanitize_text_field" sanitization has been removed from the password field because it strips strings that are considered percent-encoded characters.

## Testing Instructions

1. In the registration page, try using either of the following for the password field:
Password##%%1234
Password#%1234

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPUserManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPUserManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
