### PR TITLE
Resolved: The product is not being assigned to the user, but the payment is logged properly in Stripe

### DIFF
--- a/includes/integrations/stripe/Billing.php
+++ b/includes/integrations/stripe/Billing.php
@@ -69,6 +69,7 @@ class Billing {
 			'plan'        => $plan,
 			'success_url' => $returnUrl,
 			'cancel_url'  => $this->getBillingURL(),
+			'user_id'     => $user->ID,
 		);
 
 		if ( $stripe_account_id ) {

--- a/includes/integrations/stripe/StripeWebhookController.php
+++ b/includes/integrations/stripe/StripeWebhookController.php
@@ -168,6 +168,7 @@ class StripeWebhookController {
 		// Check if user_id exists in the metadata
 		if ( isset( $payload['data']['object']['metadata']['user_id'] ) ) {
 			$user_id = $payload['data']['object']['metadata']['user_id'];
+
 			return $this->createSubscription( $user_id, $payload, false );
 		}
 


### PR DESCRIPTION
Resolves #https://github.com/WPUserManager/wpum-stripe/issues/9

## Description
The problem stems from the fact that Stripe's 'customer.subscription.created' and 'invoice.payment_succeeded' webhook events are triggered before the creation of the subscription record in 'wpum_stripe_subscriptions.' The solution is to force the 'customer.subscription.created' webhook event handler to create the subscription record.

## Testing Instructions

1. Create a Stripe Product
2. Set up the Registration form to collect payment - https://wpusermanager.com/article/340-collecting-payment-on-registration/
3. See the described issue from the site's my-account page after the test purchase.


## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPUserManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPUserManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
