### PR TITLE
Upgrade carbon fields to 3.6.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,12 @@
     "wordpress"
   ],
   "homepage": "https://wpusermanager.com",
-  "authors": [{
-    "name": "WP User Manager",
-    "email": "hello@wpusermanager.com"
-  }],
+  "authors": [
+    {
+      "name": "WP User Manager",
+      "email": "hello@wpusermanager.com"
+    }
+  ],
   "license": [
     "GPL-3.0-or-later"
   ],
@@ -16,7 +18,7 @@
     "brain/cortex": "dev-refactoring-fastroute",
     "dompdf/dompdf": "^2.0",
     "gamajo/template-loader": "^1.3",
-    "htmlburger/carbon-fields": "^2.1",
+    "htmlburger/carbon-fields": "^3.6.9",
     "nesbot/carbon": "^2.66",
     "stripe/stripe-php": "^10.5",
     "wearerequired/wp-requirements-check": "^1.0",
@@ -51,6 +53,8 @@
     "wp-coding-standards/wpcs": "^2.3"
   },
   "autoload": {
-    "psr-4": {"WPUserManager\\Stripe\\": "includes/integrations/stripe"}
+    "psr-4": {
+      "WPUserManager\\Stripe\\": "includes/integrations/stripe"
+    }
   }
 }


### PR DESCRIPTION
Resolves #397 

## Description
The Carbon Fields package triggers a PHP deprecation notice.

## Testing Instructions

1. Enable WP_DEBUG
2. Check the debug log

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPUserManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPUserManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
