### PR TITLE
Fix: More email merge tags and html in email templates

### DIFF
--- a/includes/emails/class-wpum-emails.php
+++ b/includes/emails/class-wpum-emails.php
@@ -404,7 +404,7 @@ class WPUM_Emails {
 			),
 			array(
 				'name'        => esc_html__( 'Login page link', 'wp-user-manager' ),
-				'description' => esc_html__( 'Display the login page url.', 'wp-user-manager' ),
+				'description' => esc_html__( 'Display the login page link.', 'wp-user-manager' ),
 				'tag'         => 'login_page_link',
 				'function'    => 'wpum_email_tag_login_page_link',
 			),
@@ -416,7 +416,7 @@ class WPUM_Emails {
 			),
 			array(
 				'name'        => esc_html__( 'Password recovery link', 'wp-user-manager' ),
-				'description' => esc_html__( 'Display the password recovery link.', 'wp-user-manager' ),
+				'description' => esc_html__( 'Display the password recovery url as a link.', 'wp-user-manager' ),
 				'tag'         => 'recovery_link',
 				'function'    => 'wpum_email_tag_password_recovery_link',
 			),

--- a/includes/emails/wpum-email-functions.php
+++ b/includes/emails/wpum-email-functions.php
@@ -125,7 +125,7 @@ function wpum_email_tag_lastname( $user_id ) {
 }
 
 /**
- * Parse the {login_page_link} tag into the email to display the site login page url.
+ * Parse the {login_page_url} tag into the email to display the site login page url.
  *
  * @param string $user_id
  *
@@ -140,13 +140,13 @@ function wpum_email_tag_login_page_url( $user_id = false ) { // phpcs:ignore Gen
 }
 
 /**
- * Parse the {login_page_url} tag into the email to display the site login page url.
+ * Parse the {login_page_link} tag into the email to display the site login page url as a link.
  *
  * @param string $user_id
  *
  * @return string
  */
-function wpum_email_tag_login_page_link( $user_id = false ) {
+function wpum_email_tag_login_page_link( $user_id = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by email tag callback signature.
 
 	$login_page_url = wpum_get_core_page_id( 'login' );
 	$login_page_url = get_permalink( $login_page_url );
@@ -172,7 +172,7 @@ function wpum_email_tag_password( $user_id = false, $password_reset_key = false,
 }
 
 /**
- * Parse the {recovery_link} tag into the email to display personalized password recovery url.
+ * Parse the {recovery_url} tag into the email to display personalized password recovery url.
  *
  * @param int    $user_id
  * @param string $password_reset_key
@@ -196,7 +196,7 @@ function wpum_email_tag_password_recovery_url( $user_id, $password_reset_key, $p
 }
 
 /**
- * Parse the {recovery_url} tag into the email to display personalized password recovery url.
+ * Parse the {recovery_link} tag into the email to display personalized password recovery url as a link.
  *
  * @param int    $user_id
  * @param string $password_reset_key

--- a/tests/wpunit/Emails/EmailTagsTest.php
+++ b/tests/wpunit/Emails/EmailTagsTest.php
@@ -76,6 +76,127 @@ class EmailTagsTest extends WPUMTestCase {
 	}
 
 	/**
+	 * Test that {login_page_link} tag returns an anchor tag when email_template is set.
+	 */
+	public function test_login_page_link_tag_returns_anchor() {
+		$page_id = $this->factory()->post->create( array(
+			'post_type'   => 'page',
+			'post_title'  => 'Login Page',
+			'post_status' => 'publish',
+		) );
+
+		$page_filter = function () use ( $page_id ) {
+			return array( $page_id );
+		};
+		add_filter( 'wpum_get_option_login_page', $page_filter );
+
+		$template_filter = function () {
+			return 'default';
+		};
+		add_filter( 'wpum_get_option_email_template', $template_filter );
+
+		$result = wpum_email_tag_login_page_link( $this->test_user_id );
+
+		remove_filter( 'wpum_get_option_login_page', $page_filter );
+		remove_filter( 'wpum_get_option_email_template', $template_filter );
+
+		$this->assertStringContainsString( '<a href=', $result, 'login_page_link tag should return an HTML anchor tag.' );
+	}
+
+	/**
+	 * Test that {login_page_link} tag returns a plain URL when email_template is none.
+	 */
+	public function test_login_page_link_tag_returns_plain_url_for_none_template() {
+		$page_id = $this->factory()->post->create( array(
+			'post_type'   => 'page',
+			'post_title'  => 'Login Page',
+			'post_status' => 'publish',
+		) );
+
+		$page_filter = function () use ( $page_id ) {
+			return array( $page_id );
+		};
+		add_filter( 'wpum_get_option_login_page', $page_filter );
+
+		$template_filter = function () {
+			return 'none';
+		};
+		add_filter( 'wpum_get_option_email_template', $template_filter );
+
+		$result = wpum_email_tag_login_page_link( $this->test_user_id );
+
+		remove_filter( 'wpum_get_option_login_page', $page_filter );
+		remove_filter( 'wpum_get_option_email_template', $template_filter );
+
+		$this->assertStringNotContainsString( '<a href=', $result, 'login_page_link tag should return a plain URL when template is none.' );
+		$this->assertNotEmpty( $result );
+	}
+
+	/**
+	 * Test that {recovery_link} tag returns an anchor tag when email_template is set.
+	 */
+	public function test_recovery_link_tag_returns_anchor() {
+		$page_id = $this->factory()->post->create( array(
+			'post_type'   => 'page',
+			'post_title'  => 'Password Reset Page',
+			'post_status' => 'publish',
+		) );
+
+		$page_filter = function () use ( $page_id ) {
+			return array( $page_id );
+		};
+		add_filter( 'wpum_get_option_password_recovery_page', $page_filter );
+
+		$template_filter = function () {
+			return 'default';
+		};
+		add_filter( 'wpum_get_option_email_template', $template_filter );
+
+		$user  = get_user_by( 'id', $this->test_user_id );
+		$email = (object) array( 'user_login' => $user->user_login );
+
+		$result = wpum_email_tag_password_recovery_link( $this->test_user_id, 'test-key', '', 'recovery_link', $email );
+
+		remove_filter( 'wpum_get_option_password_recovery_page', $page_filter );
+		remove_filter( 'wpum_get_option_email_template', $template_filter );
+
+		$this->assertStringContainsString( '<a href=', $result, 'recovery_link tag should return an HTML anchor tag.' );
+		$this->assertStringContainsString( 'test-key', $result, 'recovery_link tag should include the reset key in the URL.' );
+	}
+
+	/**
+	 * Test that {recovery_link} tag returns a plain URL when email_template is none.
+	 */
+	public function test_recovery_link_tag_returns_plain_url_for_none_template() {
+		$page_id = $this->factory()->post->create( array(
+			'post_type'   => 'page',
+			'post_title'  => 'Password Reset Page',
+			'post_status' => 'publish',
+		) );
+
+		$page_filter = function () use ( $page_id ) {
+			return array( $page_id );
+		};
+		add_filter( 'wpum_get_option_password_recovery_page', $page_filter );
+
+		$template_filter = function () {
+			return 'none';
+		};
+		add_filter( 'wpum_get_option_email_template', $template_filter );
+
+		$user  = get_user_by( 'id', $this->test_user_id );
+		$email = (object) array( 'user_login' => $user->user_login );
+
+		$result = wpum_email_tag_password_recovery_link( $this->test_user_id, 'test-key', '', 'recovery_link', $email );
+
+		remove_filter( 'wpum_get_option_password_recovery_page', $page_filter );
+		remove_filter( 'wpum_get_option_email_template', $template_filter );
+
+		$this->assertStringNotContainsString( '<a href=', $result, 'recovery_link tag should return a plain URL when template is none.' );
+		$this->assertNotEmpty( $result );
+	}
+
+	/**
 	 * Test that {firstname} tag is replaced.
 	 */
 	public function test_firstname_tag_replaced() {


### PR DESCRIPTION
Resolves #309 

## Description
Added email template tags for recovery link and login page link where it returns plain URL string rather than <href> markup.

## Testing Instructions

1. Update the email template for example the `Password recovery request`.
2. Insert `Password recovery link` and `Login page link` tags.
3. Test the password reset in the frontend and check the email sent.

## Pre-review Checklist

- [ ] [Issue and pull request titles](https://github.com/WPUserManager/development-handbook/blob/master/issue-pr-titles.md) are properly formatted.
- [ ] [Acceptance criteria](https://github.com/WPUserManager/development-handbook/blob/master/acceptance-criteria.md) have been satisfied and marked in the related issue.
- [ ] Unit tests are included (if applicable).
- [ ] Self-review of code changes has been completed.
- [ ] Self-review of UX changes has been completed.
- [ ] Review has been requested from @polevaultweb.
