### PR TITLE
Auto-fix 391 WPCS 3.x coding standard violations

### DIFF
--- a/includes/abstracts/class-wpum-db.php
+++ b/includes/abstracts/class-wpum-db.php
@@ -251,5 +251,4 @@ abstract class WPUM_DB {
 	public function installed() {
 		return $this->table_exists( $this->table_name );
 	}
-
 }

--- a/includes/abstracts/class-wpum-field-type.php
+++ b/includes/abstracts/class-wpum-field-type.php
@@ -288,7 +288,6 @@ abstract class WPUM_Field_Type {
 		}
 
 		return apply_filters( 'wpum_register_field_type_settings', $settings, $this->type );
-
 	}
 
 	/**
@@ -390,5 +389,4 @@ abstract class WPUM_Field_Type {
 	public function get_formatted_output( $field, $value ) {
 		return esc_html( $value );
 	}
-
 }

--- a/includes/abstracts/class-wpum-form.php
+++ b/includes/abstracts/class-wpum-form.php
@@ -108,7 +108,6 @@ abstract class WPUM_Form {
 		if ( $next_step_key && $step_key !== $next_step_key && ! is_callable( $this->steps[ $next_step_key ]['view'] ) ) {
 			$this->process();
 		}
-
 	}
 
 	/**
@@ -213,14 +212,14 @@ abstract class WPUM_Form {
 	 * Increases step from outside of the class.
 	 */
 	public function next_step() {
-		$this->step ++;
+		++$this->step;
 	}
 
 	/**
 	 * Decreases step from outside of the class.
 	 */
 	public function previous_step() {
-		$this->step --;
+		--$this->step;
 	}
 
 	/**
@@ -515,7 +514,6 @@ abstract class WPUM_Form {
 		}
 
 		return $options;
-
 	}
 
 	/**
@@ -575,5 +573,4 @@ abstract class WPUM_Form {
 
 		return apply_filters( 'wpum_form_custom_field_dropdown_options', $options, $field );
 	}
-
 }

--- a/includes/abstracts/class-wpum-shortcode-generator.php
+++ b/includes/abstracts/class-wpum-shortcode-generator.php
@@ -93,7 +93,6 @@ abstract class WPUM_Shortcode_Generator {
 				WPUM_Shortcode_Button::$shortcodes[ $this->shortcode_tag ] = wp_parse_args( $this->shortcode, $defaults );
 			}
 		}
-
 	}
 
 	/**
@@ -142,7 +141,6 @@ abstract class WPUM_Shortcode_Generator {
 		}
 
 		return $fields;
-
 	}
 
 	/**
@@ -299,7 +297,7 @@ abstract class WPUM_Shortcode_Generator {
 
 				$this->errors[ $args['name'] ] = $this->generate_container( $error );
 			}
-			if ( ! ! $args['required'] || is_array( $args['required'] ) ) {
+			if ( (bool) $args['required'] || is_array( $args['required'] ) ) {
 				$alert = esc_html__( 'Some of the shortcode options are required.', 'wp-user-manager' );
 				if ( isset( $args['required']['alert'] ) ) {
 					$alert = $args['required']['alert'];
@@ -330,5 +328,4 @@ abstract class WPUM_Shortcode_Generator {
 			'no'  => esc_html__( 'No', 'wp-user-manager' ),
 		);
 	}
-
 }

--- a/includes/actions.php
+++ b/includes/actions.php
@@ -29,7 +29,6 @@ function wpum_delete_pages_transient( $post_id ) {
 	}
 
 	delete_transient( 'wpum_get_pages' );
-
 }
 add_action( 'save_post_page', 'wpum_delete_pages_transient' );
 
@@ -101,7 +100,6 @@ function wpum_admin_bar_menu( $wp_admin_bar ) {
 		'parent' => 'wpum_node',
 	);
 	$wp_admin_bar->add_node( $args );
-
 }
 add_action( 'admin_bar_menu', 'wpum_admin_bar_menu', 100 );
 
@@ -194,7 +192,6 @@ function wpum_restrict_wp_registration() {
 		wp_safe_redirect( esc_url( get_permalink( $registration_redirect[0] ) ) );
 		exit;
 	}
-
 }
 add_action( 'login_form_register', 'wpum_restrict_wp_registration' );
 
@@ -211,7 +208,6 @@ function wpum_restrict_wp_lostpassword() {
 		wp_safe_redirect( esc_url( get_permalink( $password_redirect[0] ) ) );
 		exit;
 	}
-
 }
 add_action( 'login_form_lostpassword', 'wpum_restrict_wp_lostpassword' );
 
@@ -228,7 +224,6 @@ function wpum_restrict_wp_profile() {
 		wp_safe_redirect( esc_url( get_permalink( $profile_redirect[0] ) ) );
 		exit;
 	}
-
 }
 add_action( 'load-profile.php', 'wpum_restrict_wp_profile' );
 
@@ -257,7 +252,6 @@ function wpum_restrict_account_page() {
 		exit;
 
 	}
-
 }
 add_action( 'template_redirect', 'wpum_restrict_account_page' );
 
@@ -283,7 +277,6 @@ function wpum_display_account_page_content() {
 	} else {
 		do_action( 'wpum_account_page_content_' . $active_tab );
 	}
-
 }
 add_action( 'wpum_account_page_content', 'wpum_display_account_page_content' );
 
@@ -488,7 +481,6 @@ function wpum_finish_db_setup_after_plugin_init() {
 	if ( ! $upgrade ) {
 		wpum_complete_setup();
 	}
-
 }
 add_action( 'after_wpum_init', 'wpum_finish_db_setup_after_plugin_init' );
 
@@ -971,7 +963,7 @@ function validate_user_meta_key() {
 add_action( 'wp_ajax_validate_user_meta_key', 'validate_user_meta_key' );
 
 
-add_action( 'the_content', function( $content ) {
+add_action( 'the_content', function ( $content ) {
 	$registration = filter_input( INPUT_GET, 'registration', FILTER_UNSAFE_RAW );
 	$registration = sanitize_text_field( $registration );
 	if ( empty( $registration ) || 'success' !== $registration ) {

--- a/includes/admin/class-wpum-addon-acf.php
+++ b/includes/admin/class-wpum-addon-acf.php
@@ -125,8 +125,6 @@ class WPUM_Addon_ACF {
 		</script>
 		<?php
 	}
-
-
 }
 
 ( new WPUM_Addon_ACF() )->init();

--- a/includes/admin/class-wpum-addon-check.php
+++ b/includes/admin/class-wpum-addon-check.php
@@ -134,5 +134,4 @@ class WPUM_Addon_Check {
 		</div>
 		<?php
 	}
-
 }

--- a/includes/admin/class-wpum-addons-page.php
+++ b/includes/admin/class-wpum-addons-page.php
@@ -31,7 +31,6 @@ class WPUM_Addons_Page {
 
 		$this->api = 'https://wpusermanager.com/wp-json/wp/v2/edd-addons';
 		$this->hooks();
-
 	}
 
 	/**
@@ -110,7 +109,6 @@ class WPUM_Addons_Page {
 	public function view_addons() {
 
 		include WPUM_PLUGIN_DIR . 'includes/admin/views/addons.php';
-
 	}
 
 	/**
@@ -125,7 +123,6 @@ class WPUM_Addons_Page {
 
 		return $tabs;
 	}
-
 }
 
 new WPUM_Addons_Page();

--- a/includes/admin/class-wpum-admin-notices.php
+++ b/includes/admin/class-wpum-admin-notices.php
@@ -71,7 +71,6 @@ class WPUM_Admin_Notices {
 			}
 			WPUM()->notices->register_notice( 'wpum_permalinks', 'warning', $message, array( 'dismissible' => false ) );
 		}
-
 	}
 
 	/**
@@ -88,7 +87,6 @@ class WPUM_Admin_Notices {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -107,7 +105,6 @@ class WPUM_Admin_Notices {
 		}
 
 		return $empty;
-
 	}
 
 	/**
@@ -124,7 +121,6 @@ class WPUM_Admin_Notices {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -159,7 +155,6 @@ class WPUM_Admin_Notices {
 			wp_die( wp_kses_post( $message ) );
 		}
 	}
-
 }
 
 new WPUM_Admin_Notices();

--- a/includes/admin/class-wpum-avatars.php
+++ b/includes/admin/class-wpum-avatars.php
@@ -225,7 +225,6 @@ class WPUM_Avatars {
 
 		return $url;
 	}
-
 }
 
 new WPUM_Avatars();

--- a/includes/admin/class-wpum-getting-started.php
+++ b/includes/admin/class-wpum-getting-started.php
@@ -308,9 +308,7 @@ class WPUM_Getting_Started {
 			wp_safe_redirect( admin_url( 'index.php?page=wpum-getting-started' ) );
 			exit;
 		}
-
 	}
-
 }
 
 new WPUM_Getting_Started();

--- a/includes/admin/class-wpum-html-elements.php
+++ b/includes/admin/class-wpum-html-elements.php
@@ -105,5 +105,4 @@ class WPUM_HTML_Elements {
 		$output .= '</select>';
 		return $output;
 	}
-
 }

--- a/includes/admin/class-wpum-menus.php
+++ b/includes/admin/class-wpum-menus.php
@@ -84,7 +84,6 @@ class WPUM_Menus {
 		}
 
 		return $roles;
-
 	}
 
 	/**
@@ -143,7 +142,6 @@ class WPUM_Menus {
 		}
 
 		return $atts;
-
 	}
 
 	/**
@@ -194,7 +192,6 @@ class WPUM_Menus {
 		}
 
 		return $items;
-
 	}
 
 	/**
@@ -220,7 +217,6 @@ class WPUM_Menus {
 
 		echo wp_kses_post( $output );
 	}
-
 }
 
 new WPUM_Menus();

--- a/includes/admin/class-wpum-options-panel.php
+++ b/includes/admin/class-wpum-options-panel.php
@@ -510,5 +510,4 @@ class WPUM_Options_Panel {
 
 		return array_merge( $settings, $plugin_settings );
 	}
-
 }

--- a/includes/admin/class-wpum-permalinks-settings.php
+++ b/includes/admin/class-wpum-permalinks-settings.php
@@ -126,7 +126,6 @@ class WPUM_Permalinks_Settings {
 			update_option( 'wpum_permalink', $user_permalink );
 		}
 	}
-
 }
 
 new WPUM_Permalinks_Settings();

--- a/includes/admin/class-wpum-plugin-updates.php
+++ b/includes/admin/class-wpum-plugin-updates.php
@@ -185,7 +185,6 @@ class WPUM_Plugin_Updates {
 
 		$message .= '<p><a href="' . $update_url . '" class="button-primary">' . esc_html__( 'Upgrade database', 'wp-user-manager' ) . '</a></p>';
 		WPUM()->notices->register_notice( 'wpumv2_upgrade_required_notice', 'warning', $message, array( 'dismissible' => false ) );
-
 	}
 
 	/**
@@ -262,7 +261,6 @@ class WPUM_Plugin_Updates {
 			$backend_profile_redirect = array( $backend_profile_redirect );
 			wpum_update_option( 'backend_profile_redirect', $backend_profile_redirect );
 		}
-
 	}
 
 	/**
@@ -288,7 +286,6 @@ class WPUM_Plugin_Updates {
 
 		$default_group = new WPUM_Field_Group( 1 );
 		$default_group->update( array( 'is_primary' => true ) );
-
 	}
 
 	/**
@@ -321,7 +318,6 @@ class WPUM_Plugin_Updates {
 				$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}wpum_field_groups" ); // phpcs:ignore
 			}
 		}
-
 	}
 
 	/**
@@ -448,7 +444,6 @@ class WPUM_Plugin_Updates {
 				}
 			}
 		}
-
 	}
 
 	/**
@@ -479,7 +474,6 @@ class WPUM_Plugin_Updates {
 		if ( ! $cover_exists ) {
 			wpum_install_cover_image_field();
 		}
-
 	}
 
 	/**
@@ -527,7 +521,6 @@ class WPUM_Plugin_Updates {
 		if ( ! empty( $new_emails ) ) {
 			update_option( 'wpum_email', $new_emails );
 		}
-
 	}
 
 	/**
@@ -544,7 +537,6 @@ class WPUM_Plugin_Updates {
 		if ( is_array( $search_fields ) && empty( $search_fields ) ) {
 			wpum_setup_default_custom_search_fields();
 		}
-
 	}
 
 	/**
@@ -583,7 +575,6 @@ class WPUM_Plugin_Updates {
 			$default_form->add_meta( 'fields', $registration_fields );
 
 		}
-
 	}
 
 	/**
@@ -643,7 +634,6 @@ class WPUM_Plugin_Updates {
 			wp_reset_postdata();
 
 		}
-
 	}
 
 	/**
@@ -695,7 +685,5 @@ class WPUM_Plugin_Updates {
 
 			wp_die( wp_kses_post( $message ), 'WPUM DB Update' );
 		}
-
 	}
-
 }

--- a/includes/admin/class-wpum-prevent-password-change.php
+++ b/includes/admin/class-wpum-prevent-password-change.php
@@ -27,7 +27,6 @@ class WPUM_Prevent_Password_Change {
 
 		add_action( 'carbon_fields_register_fields', array( $this, 'register_custom_field' ) );
 		add_filter( 'submit_wpum_form_validate_fields', array( $this, 'prevent_change' ), 10, 4 );
-
 	}
 
 	/**
@@ -65,9 +64,7 @@ class WPUM_Prevent_Password_Change {
 		}
 
 		return $pass;
-
 	}
-
 }
 
 new WPUM_Prevent_Password_Change();

--- a/includes/admin/class-wpum-template-loader.php
+++ b/includes/admin/class-wpum-template-loader.php
@@ -44,5 +44,4 @@ class WPUM_Template_Loader extends WPUM\Gamajo_Template_Loader {
 	 * @var string
 	 */
 	protected $plugin_template_directory = 'templates';
-
 }

--- a/includes/admin/class-wpum-user-meta-custom-datastore.php
+++ b/includes/admin/class-wpum-user-meta-custom-datastore.php
@@ -20,7 +20,6 @@ class WPUM_User_Meta_Custom_Datastore extends Datastore {
 	 * Initialization tasks for concrete datastores.
 	 **/
 	public function init() {
-
 	}
 
 	/**

--- a/includes/admin/class-wpum-user-table.php
+++ b/includes/admin/class-wpum-user-table.php
@@ -157,7 +157,7 @@ class WPUM_User_Table {
 
 			if ( ! in_array( $role, $user->roles, true ) ) {
 				$user->add_role( $role );
-				$count ++;
+				++$count;
 			}
 		}
 		wp_safe_redirect( add_query_arg( array(
@@ -248,7 +248,7 @@ class WPUM_User_Table {
 
 			if ( in_array( $role, $user->roles, true ) ) {
 				$user->remove_role( $role );
-				$count ++;
+				++$count;
 			}
 		}
 		wp_safe_redirect( add_query_arg( array(
@@ -287,7 +287,6 @@ class WPUM_User_Table {
 
 		return $value;
 	}
-
 }
 
 new WPUM_User_Table();

--- a/includes/class-wp-user-manager.php
+++ b/includes/class-wp-user-manager.php
@@ -452,7 +452,7 @@ if ( ! class_exists( 'WP_User_Manager' ) ) :
 			( new WPUM_Plugin_Updates() )->init();
 
 			/** @phpstan-ignore-next-line Class is conditionally loaded when Elementor is active. */
-		( new WPUM_Elementor_Loader() )::get_instance();
+			( new WPUM_Elementor_Loader() )::get_instance();
 
 			$this->field_types = new WPUM_Fields();
 			$this->field_types->init();
@@ -489,7 +489,7 @@ if ( ! class_exists( 'WP_User_Manager' ) ) :
 			$this->carbon_fields();
 
 			/** @phpstan-ignore-next-line Library docblock says void but actually returns instance. */
-		$this->notices                = \WPUM\TDP\WP_Notice::instance();
+			$this->notices                = \WPUM\TDP\WP_Notice::instance();
 			$this->forms                  = WPUM_Forms::instance();
 			$this->templates              = new WPUM_Template_Loader();
 			$this->emails                 = new WPUM_Emails();
@@ -504,7 +504,6 @@ if ( ! class_exists( 'WP_User_Manager' ) ) :
 			require_once WPUM_PLUGIN_DIR . 'includes/shortcodes/shortcodes.php';
 
 			do_action( 'after_wpum_init' );
-
 		}
 
 		/**
@@ -580,7 +579,6 @@ if ( ! class_exists( 'WP_User_Manager' ) ) :
 			if ( ! defined( 'WPUM_SLUG' ) ) {
 				define( 'WPUM_SLUG', plugin_basename( $this->plugin_file ) );
 			}
-
 		}
 
 		/**
@@ -624,7 +622,6 @@ if ( ! class_exists( 'WP_User_Manager' ) ) :
 				( new WPUM_Addon_Check( $addon ) )->passes();
 			}
 		}
-
 	}
 
 endif; // End if class_exists check.

--- a/includes/database/class-wpum-db-field-meta.php
+++ b/includes/database/class-wpum-db-field-meta.php
@@ -145,5 +145,4 @@ class WPUM_DB_Field_Meta extends WPUM_DB {
 		}
 		return absint( $field_id );
 	}
-
 }

--- a/includes/database/class-wpum-db-fields-groups.php
+++ b/includes/database/class-wpum-db-fields-groups.php
@@ -317,5 +317,4 @@ class WPUM_DB_Fields_Groups extends WPUM_DB {
 
 		return absint( $count );
 	}
-
 }

--- a/includes/database/class-wpum-db-fields.php
+++ b/includes/database/class-wpum-db-fields.php
@@ -270,7 +270,6 @@ class WPUM_DB_Fields extends WPUM_DB {
 		}
 
 		return $fields;
-
 	}
 
 	/**
@@ -309,5 +308,4 @@ class WPUM_DB_Fields extends WPUM_DB {
 
 		return $where;
 	}
-
 }

--- a/includes/database/class-wpum-db-registration-form-meta.php
+++ b/includes/database/class-wpum-db-registration-form-meta.php
@@ -137,5 +137,4 @@ class WPUM_DB_Registration_Form_Meta extends WPUM_DB {
 
 		return absint( $form_id );
 	}
-
 }

--- a/includes/database/class-wpum-db-registration-forms.php
+++ b/includes/database/class-wpum-db-registration-forms.php
@@ -259,5 +259,4 @@ class WPUM_DB_Registration_Forms extends WPUM_DB {
 
 		return $where;
 	}
-
 }

--- a/includes/database/class-wpum-db-search-fields.php
+++ b/includes/database/class-wpum-db-search-fields.php
@@ -148,5 +148,4 @@ class WPUM_DB_Search_Fields extends WPUM_DB {
 
 		return $last_changed;
 	}
-
 }

--- a/includes/database/class-wpum-db-table-field-meta.php
+++ b/includes/database/class-wpum-db-table-field-meta.php
@@ -57,5 +57,4 @@ final class WPUM_DB_Table_Field_Meta extends WPUM_DB_Table {
 	 * @return void
 	 */
 	protected function upgrade() {}
-
 }

--- a/includes/database/class-wpum-db-table-fields-groups.php
+++ b/includes/database/class-wpum-db-table-fields-groups.php
@@ -58,5 +58,4 @@ final class WPUM_DB_Table_Fields_Groups extends WPUM_DB_Table {
 	 * @return void
 	 */
 	protected function upgrade() {}
-
 }

--- a/includes/database/class-wpum-db-table-fields.php
+++ b/includes/database/class-wpum-db-table-fields.php
@@ -59,5 +59,4 @@ final class WPUM_DB_Table_Fields extends WPUM_DB_Table {
 	 * @return void
 	 */
 	protected function upgrade() {}
-
 }

--- a/includes/database/class-wpum-db-table-registration-forms-meta.php
+++ b/includes/database/class-wpum-db-table-registration-forms-meta.php
@@ -57,5 +57,4 @@ final class WPUM_DB_Table_Registration_Forms_Meta extends WPUM_DB_Table {
 	 * @return void
 	 */
 	protected function upgrade() {}
-
 }

--- a/includes/database/class-wpum-db-table-registration-forms.php
+++ b/includes/database/class-wpum-db-table-registration-forms.php
@@ -52,5 +52,4 @@ final class WPUM_DB_Table_Registration_Forms extends WPUM_DB_Table {
 	 * @return void
 	 */
 	protected function upgrade() {}
-
 }

--- a/includes/database/class-wpum-db-table-search-fields.php
+++ b/includes/database/class-wpum-db-table-search-fields.php
@@ -52,5 +52,4 @@ final class WPUM_DB_Table_Search_Fields extends WPUM_DB_Table {
 	 * @return void
 	 */
 	protected function upgrade() {}
-
 }

--- a/includes/database/class-wpum-db-table.php
+++ b/includes/database/class-wpum-db-table.php
@@ -43,5 +43,4 @@ class WPUM_DB_Table extends WPUM_WP_DB_Table {
 	 * @return void
 	 */
 	protected function upgrade() {}
-
 }

--- a/includes/directories/class-wpum-directories-editor.php
+++ b/includes/directories/class-wpum-directories-editor.php
@@ -99,7 +99,6 @@ class WPUM_Directories_Editor {
 			'show_in_rest'        => true,
 		);
 		register_post_type( 'wpum_directory', $args );
-
 	}
 
 	/**
@@ -154,20 +153,20 @@ class WPUM_Directories_Editor {
 
 		$general_settings_fields = array(
 			Field::make( 'multiselect', 'directory_assigned_roles', esc_html__( 'User roles', 'wp-user-manager' ) )
-				 ->set_help_text( esc_html__( 'Leave blank to display all user roles.', 'wp-user-manager' ) )
-				 ->add_options( $this->get_roles() ),
+				->set_help_text( esc_html__( 'Leave blank to display all user roles.', 'wp-user-manager' ) )
+				->add_options( $this->get_roles() ),
 			Field::make( 'text', 'directory_excluded_users', esc_html__( 'Exclude users', 'wp-user-manager' ) )
-				 ->set_attribute( 'placeholder', esc_html__( 'Example: 1, 6, 32', 'wp-user-manager' ) )
-				 ->set_help_text( esc_html__( 'Comma separated list of users id you wish to exclude.', 'wp-user-manager' ) ),
+				->set_attribute( 'placeholder', esc_html__( 'Example: 1, 6, 32', 'wp-user-manager' ) )
+				->set_help_text( esc_html__( 'Comma separated list of users id you wish to exclude.', 'wp-user-manager' ) ),
 			Field::make( 'text', 'directory_profiles_per_page', esc_html__( 'Profiles per page', 'wp-user-manager' ) )
-				 ->set_attribute( 'type', 'number' )
-				 ->set_attribute( 'min', 1 )
-				 ->set_help_text( esc_html__( 'Select how many profiles you wish to display per page.', 'wp-user-manager' ) ),
+				->set_attribute( 'type', 'number' )
+				->set_attribute( 'min', 1 )
+				->set_help_text( esc_html__( 'Select how many profiles you wish to display per page.', 'wp-user-manager' ) ),
 		);
 
 		Container::make( 'post_meta', esc_html__( 'General settings', 'wp-user-manager' ) )
-				 ->where( 'post_type', '=', 'wpum_directory' )
-				 ->add_fields( apply_filters( 'wpum_directory_general_settings', $general_settings_fields ) );
+				->where( 'post_type', '=', 'wpum_directory' )
+				->add_fields( apply_filters( 'wpum_directory_general_settings', $general_settings_fields ) );
 
 		// translators: %s url to custom fields addon
 		$search_field_text = sprintf( __( 'Select the fields to search in. Search custom fields using the <a href="%s" target="_blank">Custom Fields</a> addon.', 'wp-user-manager' ), 'https://wpusermanager.com/addons/custom-fields?utm_source=WP%20User%20Manager&utm_medium=insideplugin&utm_campaign=WP%20User%20Manager&utm_content=edit-directory' );
@@ -175,27 +174,27 @@ class WPUM_Directories_Editor {
 
 		$search_fields = array(
 			Field::make( 'checkbox', 'directory_search_form', esc_html__( 'Display search form', 'wp-user-manager' ) )
-				 ->set_option_value( 'yes' )
-				 ->set_help_text( esc_html__( 'Enable this option to display the user search form', 'wp-user-manager' ) ),
+				->set_option_value( 'yes' )
+				->set_help_text( esc_html__( 'Enable this option to display the user search form', 'wp-user-manager' ) ),
 			Field::make( 'multiselect', 'directory_search_fields', esc_html__( 'Search fields', 'wp-user-manager' ) )
-				 ->set_help_text( $search_field_text )
-				 ->add_options( $this->get_search_fields() )
-				 ->set_default_value( array( 'first_name', 'last_name' ) ),
+				->set_help_text( $search_field_text )
+				->add_options( $this->get_search_fields() )
+				->set_default_value( array( 'first_name', 'last_name' ) ),
 		);
 
 		Container::make( 'post_meta', esc_html__( 'Search', 'wp-user-manager' ) )
-				 ->where( 'post_type', '=', 'wpum_directory' )
-				 ->add_fields( apply_filters( 'wpum_directory_search_settings', $search_fields ) );
+				->where( 'post_type', '=', 'wpum_directory' )
+				->add_fields( apply_filters( 'wpum_directory_search_settings', $search_fields ) );
 
 		$sorting_fields = array(
 			Field::make( 'checkbox', 'directory_display_sorter', esc_html__( 'Display sorter', 'wp-user-manager' ) )
-				 ->set_option_value( 'yes' )
-				 ->set_help_text( esc_html__( 'Enable this setting to display a dropdown menu into the directory with the sorting options.', 'wp-user-manager' ) ),
+				->set_option_value( 'yes' )
+				->set_help_text( esc_html__( 'Enable this setting to display a dropdown menu into the directory with the sorting options.', 'wp-user-manager' ) ),
 			Field::make( 'checkbox', 'directory_display_amount_filter', esc_html__( 'Display amount filter', 'wp-user-manager' ) )
-				 ->set_option_value( 'yes' )
-				 ->set_help_text( esc_html__( 'Enable this setting to display a dropdown menu into the directory with the results amount filter.', 'wp-user-manager' ) ),
+				->set_option_value( 'yes' )
+				->set_help_text( esc_html__( 'Enable this setting to display a dropdown menu into the directory with the results amount filter.', 'wp-user-manager' ) ),
 			Field::make( 'select', 'directory_sorting_method', esc_html__( 'Sorting method', 'wp-user-manager' ) )
-				 ->set_help_text( esc_html__( 'Select the sorting method for the directory. If the sorter field is visible, this will be used as default option.', 'wp-user-manager' ) )
+				->set_help_text( esc_html__( 'Select the sorting method for the directory. If the sorter field is visible, this will be used as default option.', 'wp-user-manager' ) )
 				->add_options( apply_filters( 'wpum_directory_sort_options', array(
 					'newest'    => esc_html__( 'Newest users first', 'wp-user-manager' ),
 					'oldest'    => esc_html__( 'Oldest users first', 'wp-user-manager' ),
@@ -205,23 +204,23 @@ class WPUM_Directories_Editor {
 		);
 
 		Container::make( 'post_meta', esc_html__( 'Sorting', 'wp-user-manager' ) )
-				 ->where( 'post_type', '=', 'wpum_directory' )
-				 ->add_fields( apply_filters( 'wpum_directory_sorting_settings', $sorting_fields ) );
+				->where( 'post_type', '=', 'wpum_directory' )
+				->add_fields( apply_filters( 'wpum_directory_sorting_settings', $sorting_fields ) );
 
 		$template_fields = array(
 			Field::make( 'select', 'directory_template', esc_html__( 'Template', 'wp-user-manager' ) )
-				 ->set_help_text( esc_html__( 'Select a template for this directory.', 'wp-user-manager' ) )
-				 ->add_options( wpum_get_directory_templates() ),
+				->set_help_text( esc_html__( 'Select a template for this directory.', 'wp-user-manager' ) )
+				->add_options( wpum_get_directory_templates() ),
 			Field::make( 'select', 'directory_user_template', esc_html__( 'User Template', 'wp-user-manager' ) )
-				 ->set_help_text( esc_html__( 'Select a template for the users within this directory.', 'wp-user-manager' ) )
-				 ->add_options( wpum_get_directory_user_templates() ),
+				->set_help_text( esc_html__( 'Select a template for the users within this directory.', 'wp-user-manager' ) )
+				->add_options( wpum_get_directory_user_templates() ),
 		);
 
 		Container::make( 'post_meta', esc_html__( 'Directory template', 'wp-user-manager' ) )
-				 ->where( 'post_type', '=', 'wpum_directory' )
-				 ->set_context( 'side' )
-				 ->set_priority( 'default' )
-				 ->add_fields( apply_filters( 'wpum_directory_template_settings', $template_fields ) );
+				->where( 'post_type', '=', 'wpum_directory' )
+				->set_context( 'side' )
+				->set_priority( 'default' )
+				->add_fields( apply_filters( 'wpum_directory_template_settings', $template_fields ) );
 
 		do_action( 'wpum_after_register_directory_settings' );
 	}
@@ -240,7 +239,6 @@ class WPUM_Directories_Editor {
 		}
 
 		return $roles;
-
 	}
 
 	/**

--- a/includes/directories/wpum-directories-functions.php
+++ b/includes/directories/wpum-directories-functions.php
@@ -27,7 +27,6 @@ function wpum_get_directory_sort_by_methods() {
 	);
 
 	return apply_filters( 'wpum_get_directory_sort_by_methods', $options );
-
 }
 
 /**
@@ -46,7 +45,6 @@ function wpum_get_directory_amount_modifier() {
 	);
 
 	return apply_filters( 'wpum_get_directory_amount_modifier', $amounts );
-
 }
 
 /**
@@ -61,7 +59,6 @@ function wpum_get_directory_templates() {
 	);
 
 	return apply_filters( 'wpum_get_directory_templates', $templates );
-
 }
 
 /**
@@ -76,7 +73,6 @@ function wpum_get_directory_user_templates() {
 	);
 
 	return apply_filters( 'wpum_get_directory_user_templates', $templates );
-
 }
 
 /**
@@ -102,5 +98,4 @@ function wpum_user_directory_pagination( $data ) {
 	) ) );
 
 	echo '</div>';
-
 }

--- a/includes/emails/class-wpum-emails-customizer-editor-control.php
+++ b/includes/emails/class-wpum-emails-customizer-editor-control.php
@@ -56,7 +56,5 @@ class WPUM_Emails_Customizer_Editor_Control extends WP_Customize_Control {
 		<br/>
 
 		<?php
-
 	}
-
 }

--- a/includes/emails/class-wpum-emails-customizer-scripts.php
+++ b/includes/emails/class-wpum-emails-customizer-scripts.php
@@ -48,7 +48,6 @@ class WPUM_Emails_Customizer_Scripts {
 		);
 
 		wp_localize_script( 'wpum-email-customize-preview', 'wpumCustomizePreview', $js_variables );
-
 	}
 
 	/**
@@ -82,9 +81,7 @@ class WPUM_Emails_Customizer_Scripts {
 			'sections'          => $sections,
 		);
 		wp_localize_script( 'wpum-email-customize-controls', 'wpumCustomizeControls', $js_variables );
-
 	}
-
 }
 
 new WPUM_Emails_Customizer_Scripts();

--- a/includes/emails/class-wpum-emails-customizer.php
+++ b/includes/emails/class-wpum-emails-customizer.php
@@ -181,7 +181,6 @@ class WPUM_Emails_Customizer {
 
 			}
 		}
-
 	}
 
 	/**
@@ -242,7 +241,6 @@ class WPUM_Emails_Customizer {
 			'description' => esc_html__( 'Click the button to open the content customization editor.', 'wp-user-manager' ),
 			'section'     => $email_id . '_settings',
 		) ) );
-
 	}
 
 	/**
@@ -279,7 +277,6 @@ class WPUM_Emails_Customizer {
 		}
 
 		return $default;
-
 	}
 
 	/**
@@ -302,9 +299,7 @@ class WPUM_Emails_Customizer {
 				->get_template_part( 'email-customizer-preview' );
 			exit;
 		}
-
 	}
-
 }
 
 new WPUM_Emails_Customizer();

--- a/includes/emails/class-wpum-emails-list.php
+++ b/includes/emails/class-wpum-emails-list.php
@@ -107,7 +107,6 @@ class WPUM_Emails_List {
 			wp_localize_script( 'wpum-emails-editor', 'wpumEmailsEditor', $js_variables );
 
 		}
-
 	}
 
 	/**
@@ -146,7 +145,6 @@ class WPUM_Emails_List {
 		}
 
 		wp_send_json_success();
-
 	}
 
 	/**
@@ -173,7 +171,6 @@ class WPUM_Emails_List {
 		}
 
 		wp_send_json_success();
-
 	}
 }
 

--- a/includes/emails/class-wpum-emails.php
+++ b/includes/emails/class-wpum-emails.php
@@ -105,7 +105,6 @@ class WPUM_Emails {
 
 		add_action( 'wpum_email_send_before', array( $this, 'send_before' ) );
 		add_action( 'wpum_email_send_after', array( $this, 'send_after' ) );
-
 	}
 
 	/**
@@ -278,7 +277,6 @@ class WPUM_Emails {
 		do_action( 'wpum_email_send_after', $this );
 
 		return $sent;
-
 	}
 
 	/**
@@ -413,7 +411,6 @@ class WPUM_Emails {
 		);
 
 		return apply_filters( 'wpum_email_tags', $email_tags, $this );
-
 	}
 
 	/**
@@ -443,5 +440,4 @@ class WPUM_Emails {
 	public function email_tag_exists( $tag ) {
 		return array_key_exists( $tag, $this->tags );
 	}
-
 }

--- a/includes/emails/wpum-email-functions.php
+++ b/includes/emails/wpum-email-functions.php
@@ -221,7 +221,6 @@ function wpum_get_registered_emails() {
 	);
 
 	return apply_filters( 'wpum_registered_emails', $emails );
-
 }
 
 /**
@@ -249,7 +248,6 @@ function wpum_get_email_field( $email_id = false, $field_id = false ) {
 	}
 
 	return $output;
-
 }
 
 /**

--- a/includes/fields/class-wpum-field-group.php
+++ b/includes/fields/class-wpum-field-group.php
@@ -102,7 +102,6 @@ class WPUM_Field_Group {
 		} else {
 			return false;
 		}
-
 	}
 
 	/**
@@ -166,7 +165,6 @@ class WPUM_Field_Group {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -283,7 +281,6 @@ class WPUM_Field_Group {
 		do_action( 'wpum_post_insert_field_group', $args, $this->id );
 
 		return $id;
-
 	}
 
 	/**
@@ -316,7 +313,6 @@ class WPUM_Field_Group {
 		do_action( 'wpum_post_update_field_group', $args, $this->id );
 
 		return $ret;
-
 	}
 
 	/**
@@ -360,7 +356,6 @@ class WPUM_Field_Group {
 		}
 
 		return $data;
-
 	}
 
 	/**
@@ -390,5 +385,4 @@ class WPUM_Field_Group {
 
 		return $count;
 	}
-
 }

--- a/includes/fields/class-wpum-field.php
+++ b/includes/fields/class-wpum-field.php
@@ -158,7 +158,6 @@ class WPUM_Field {
 		} else {
 			return false;
 		}
-
 	}
 
 	/**
@@ -223,7 +222,6 @@ class WPUM_Field {
 		}
 
 		return false;
-
 	}
 
 	/**
@@ -455,7 +453,6 @@ class WPUM_Field {
 		}
 
 		return $primary;
-
 	}
 
 	/**
@@ -518,7 +515,6 @@ class WPUM_Field {
 		do_action( 'wpum_post_insert_field', $args, $this->id );
 
 		return $id;
-
 	}
 
 	/**
@@ -551,7 +547,6 @@ class WPUM_Field {
 		do_action( 'wpum_post_update_field', $args, $this->id );
 
 		return $ret;
-
 	}
 
 	/**
@@ -595,7 +590,6 @@ class WPUM_Field {
 		}
 
 		return $data;
-
 	}
 
 	/**
@@ -647,7 +641,6 @@ class WPUM_Field {
 			$value       = $this->format_value( $value );
 			$this->value = $value;
 		}
-
 	}
 
 	/**

--- a/includes/fields/class-wpum-fields-editor.php
+++ b/includes/fields/class-wpum-fields-editor.php
@@ -125,7 +125,6 @@ class WPUM_Fields_Editor {
 			wp_localize_script( 'wpum-fields-editor', 'wpumFieldsEditor', $js_variables );
 
 		}
-
 	}
 
 	/**
@@ -206,7 +205,6 @@ class WPUM_Fields_Editor {
 			'repeater_fields_create'    => esc_html__( 'Add sub field', 'wp-user-manager' ),
 			'confirm_message'           => esc_html__( 'Are you sure you want to leave? You have unsaved field settings.', 'wp-user-manager' ),
 		);
-
 	}
 
 	/**
@@ -237,7 +235,6 @@ class WPUM_Fields_Editor {
 		}
 
 		return $registered_groups;
-
 	}
 
 	/**
@@ -267,7 +264,6 @@ class WPUM_Fields_Editor {
 		}
 		$this->delete_groups_cache();
 		wp_send_json_success( $groups );
-
 	}
 
 	/**
@@ -309,7 +305,6 @@ class WPUM_Fields_Editor {
 				'description' => $group_description,
 			)
 		);
-
 	}
 
 	/**
@@ -401,7 +396,6 @@ class WPUM_Fields_Editor {
 				'group_id' => $group_id,
 			)
 		);
-
 	}
 
 	/**
@@ -434,7 +428,6 @@ class WPUM_Fields_Editor {
 
 		$this->delete_group_fields_cache( $group_id );
 		wp_send_json_success( $fields );
-
 	}
 
 	/**
@@ -492,7 +485,6 @@ class WPUM_Fields_Editor {
 		} else {
 			wp_send_json_error( null, 403 );
 		}
-
 	}
 
 	/**
@@ -528,7 +520,6 @@ class WPUM_Fields_Editor {
 		}
 
 		return apply_filters( 'wpum_fields_editor_deregister_settings', $settings, $wpum_field->get_primary_id(), $wpum_field );
-
 	}
 
 	/**
@@ -548,7 +539,6 @@ class WPUM_Fields_Editor {
 		}
 
 		return apply_filters( 'wpum_fields_editor_deregister_model', $model, $primary_field_id );
-
 	}
 
 	/**
@@ -581,7 +571,6 @@ class WPUM_Fields_Editor {
 		}
 
 		return $exists;
-
 	}
 
 	/**
@@ -629,19 +618,17 @@ class WPUM_Fields_Editor {
 				} else {
 					$value = $field->get_meta( $setting_id );
 				}
-			} else {
-				if ( 'checkbox' === $type ) {
+			} elseif ( 'checkbox' === $type ) {
 					$value = (bool) $field->get_meta( $setting_id );
-				} else {
-					$default_method = 'default_' . $setting_id;
-					if ( method_exists( $field->field_type, $default_method ) ) {
-						if ( ! $field->meta_exists( $setting_id ) ) {
-							return $field->field_type->{$default_method}();
-						}
+			} else {
+				$default_method = 'default_' . $setting_id;
+				if ( method_exists( $field->field_type, $default_method ) ) {
+					if ( ! $field->meta_exists( $setting_id ) ) {
+						return $field->field_type->{$default_method}();
 					}
-
-					$value = $field->get_meta( $setting_id );
 				}
+
+				$value = $field->get_meta( $setting_id );
 			}
 		}
 
@@ -785,9 +772,7 @@ class WPUM_Fields_Editor {
 		} else {
 			wp_send_json_error( null, 403 );
 		}
-
 	}
-
 }
 
 new WPUM_Fields_Editor();

--- a/includes/fields/class-wpum-fields-query.php
+++ b/includes/fields/class-wpum-fields-query.php
@@ -114,7 +114,6 @@ class WPUM_Fields_Query {
 		$this->groups      = $groups;
 		$this->group_count = count( $this->groups );
 		$this->user_id     = $args['user_id'];
-
 	}
 
 	/**
@@ -138,7 +137,7 @@ class WPUM_Fields_Query {
 	 */
 	public function next_group() {
 
-		$this->current_group++;
+		++$this->current_group;
 		$this->group       = $this->groups[ $this->current_group ];
 		$this->field_count = 0;
 		$this->group       = $this->group;
@@ -149,7 +148,6 @@ class WPUM_Fields_Query {
 		}
 
 		return $this->group;
-
 	}
 
 	/**
@@ -163,7 +161,6 @@ class WPUM_Fields_Query {
 		if ( $this->group_count > 0 ) {
 			$this->group = $this->groups[0];
 		}
-
 	}
 
 	/**
@@ -217,7 +214,7 @@ class WPUM_Fields_Query {
 			}
 
 			if ( 'public' !== $field->get_visibility() ) {
-				$hidden_fields++;
+				++$hidden_fields;
 			}
 		}
 
@@ -236,7 +233,7 @@ class WPUM_Fields_Query {
 	 * @return object field details.
 	 */
 	public function next_field() {
-		$this->current_field++;
+		++$this->current_field;
 		$this->field = $this->group->get_fields()[ $this->current_field ];
 		return $this->field;
 	}
@@ -296,8 +293,5 @@ class WPUM_Fields_Query {
 		} else {
 			$this->field_has_data = false;
 		}
-
 	}
-
-
 }

--- a/includes/fields/class-wpum-fields.php
+++ b/includes/fields/class-wpum-fields.php
@@ -82,7 +82,6 @@ class WPUM_Fields {
 				( new $class() )->register();
 			}
 		}
-
 	}
 
 	/**
@@ -146,5 +145,4 @@ class WPUM_Fields {
 
 		return $this->field_type_names;
 	}
-
 }

--- a/includes/fields/types/class-wpum-field-audio.php
+++ b/includes/fields/types/class-wpum-field-audio.php
@@ -36,5 +36,4 @@ class WPUM_Field_Audio extends WPUM_Field_File {
 	public function default_allowed_mime_types() {
 		return 'mp3,m4a,ogg,wav';
 	}
-
 }

--- a/includes/fields/types/class-wpum-field-checkbox.php
+++ b/includes/fields/types/class-wpum-field-checkbox.php
@@ -39,6 +39,4 @@ class WPUM_Field_Checkbox extends WPUM_Field_Type {
 	public function get_formatted_output( $field, $value ) {
 		return esc_html__( 'Yes', 'wp-user-manager' );
 	}
-
 }
-

--- a/includes/fields/types/class-wpum-field-dropdown.php
+++ b/includes/fields/types/class-wpum-field-dropdown.php
@@ -50,5 +50,4 @@ class WPUM_Field_Dropdown extends WPUM_Field_Type {
 
 		return $value;
 	}
-
 }

--- a/includes/fields/types/class-wpum-field-hidden.php
+++ b/includes/fields/types/class-wpum-field-hidden.php
@@ -29,4 +29,3 @@ class WPUM_Field_Hidden extends WPUM_Field_Type {
 		$this->min_addon_version = '2.2.1';
 	}
 }
-

--- a/includes/fields/types/class-wpum-field-multicheckbox.php
+++ b/includes/fields/types/class-wpum-field-multicheckbox.php
@@ -51,7 +51,6 @@ class WPUM_Field_Multicheckbox extends WPUM_Field_Type {
 		}
 
 		return implode( ', ', $values );
-
 	}
 
 	/**

--- a/includes/fields/types/class-wpum-field-multiselect.php
+++ b/includes/fields/types/class-wpum-field-multiselect.php
@@ -62,7 +62,5 @@ class WPUM_Field_Multiselect extends WPUM_Field_Type {
 		}
 
 		return implode( ', ', $values );
-
 	}
-
 }

--- a/includes/fields/types/class-wpum-field-number.php
+++ b/includes/fields/types/class-wpum-field-number.php
@@ -78,5 +78,4 @@ class WPUM_Field_Number extends WPUM_Field_Type {
 			),
 		);
 	}
-
 }

--- a/includes/fields/types/class-wpum-field-taxonomy.php
+++ b/includes/fields/types/class-wpum-field-taxonomy.php
@@ -115,5 +115,4 @@ class WPUM_Field_Taxonomy extends WPUM_Field_Type {
 
 		return implode( ', ', $values );
 	}
-
 }

--- a/includes/fields/types/class-wpum-field-telephone.php
+++ b/includes/fields/types/class-wpum-field-telephone.php
@@ -65,5 +65,4 @@ class WPUM_Field_Telephone extends WPUM_Field_Type {
 			),
 		);
 	}
-
 }

--- a/includes/fields/types/class-wpum-field-text.php
+++ b/includes/fields/types/class-wpum-field-text.php
@@ -60,6 +60,4 @@ class WPUM_Field_Text extends WPUM_Field_Type {
 			),
 		);
 	}
-
 }
-

--- a/includes/fields/types/class-wpum-field-textarea.php
+++ b/includes/fields/types/class-wpum-field-textarea.php
@@ -78,5 +78,4 @@ class WPUM_Field_Textarea extends WPUM_Field_Type {
 			),
 		);
 	}
-
 }

--- a/includes/fields/types/class-wpum-field-video.php
+++ b/includes/fields/types/class-wpum-field-video.php
@@ -36,5 +36,4 @@ class WPUM_Field_Video extends WPUM_Field_File {
 	public function default_allowed_mime_types() {
 		return 'mp4,m4v,mov,wmv,avi,mpg';
 	}
-
 }

--- a/includes/fields/wpum-fields-functions.php
+++ b/includes/fields/wpum-fields-functions.php
@@ -158,7 +158,7 @@ function wpum_install_fields() {
 
 		foreach ( $fields as $field ) {
 
-			$order++;
+			++$order;
 			$field['field_order'] = $order;
 
 			$save_field = new WPUM_Field();
@@ -195,7 +195,6 @@ function wpum_install_cover_image_field() {
 	$save_field->add_meta( 'user_meta_key', 'user_cover' );
 	$save_field->add_meta( 'editing', 'public' );
 	$save_field->add_meta( 'visibility', 'public' );
-
 }
 
 /**
@@ -220,7 +219,6 @@ function wpum_get_primary_field_types() {
 	);
 
 	return apply_filters( 'wpum_get_primary_field_types', $types );
-
 }
 
 /**
@@ -258,7 +256,6 @@ function wpum_get_edit_field_dialog_tabs() {
 	);
 
 	return apply_filters( 'wpum_get_fields_editor_edit_tabs', $tabs );
-
 }
 
 /**
@@ -537,7 +534,6 @@ function wpum_get_field_css_class( $class = false ) {
 	$classes = array_map( 'esc_attr', $classes );
 
 	return apply_filters( 'wpum_field_css_class', $classes, $class );
-
 }
 
 /**

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -86,7 +86,6 @@ function wpum_set_lostpassword_url( $url, $redirect ) {
 	} else {
 		return $url;
 	}
-
 }
 add_filter( 'lostpassword_url', 'wpum_set_lostpassword_url', 10, 2 );
 
@@ -133,7 +132,6 @@ function wpum_login_url( $login_url, $redirect, $force_reauth ) {
 	}
 
 	return $wpum_login_page;
-
 }
 if ( wpum_get_option( 'lock_wplogin' ) || wpum_get_option( 'lock_complete_site' ) ) {
 	add_filter( 'login_url', 'wpum_login_url', 10, 3 );
@@ -181,7 +179,6 @@ function wpum_authentication( $wp_user, $username, $password ) {
 	}
 
 	return $wp_user;
-
 }
 add_filter( 'authenticate', 'wpum_authentication', 20, 3 );
 
@@ -212,7 +209,6 @@ function wpum_highlight_pages( $post_states, $post ) {
 	}
 
 	return $post_states;
-
 }
 add_filter( 'display_post_states', 'wpum_highlight_pages', 10, 2 );
 
@@ -406,4 +402,3 @@ if ( wpum_get_option( 'obfuscate_display_name_emails' ) ) {
 		return wpum_mask_email_address( $display_name );
 	}, 10, 2 );
 }
-

--- a/includes/forms/class-wpum-form-login.php
+++ b/includes/forms/class-wpum-form-login.php
@@ -72,7 +72,6 @@ class WPUM_Form_Login extends WPUM_Form {
 		) );
 
 		$this->sort_set_steps();
-
 	}
 
 	/**
@@ -107,7 +106,6 @@ class WPUM_Form_Login extends WPUM_Form {
 				),
 			),
 		) );
-
 	}
 
 	/**
@@ -129,7 +127,6 @@ class WPUM_Form_Login extends WPUM_Form {
 		WPUM()->templates
 			->set_template_data( $data )
 			->get_template_part( 'forms/form', 'login' );
-
 	}
 
 	/**
@@ -170,7 +167,7 @@ class WPUM_Form_Login extends WPUM_Form {
 			}
 
 			// Successful, show next step.
-			$this->step ++;
+			++$this->step;
 
 		} catch ( Exception $e ) {
 			$this->add_error( $e->getMessage(), 'login_submit' );
@@ -230,7 +227,5 @@ class WPUM_Form_Login extends WPUM_Form {
 			$this->add_error( $e->getMessage(), 'login_done' );
 			return;
 		}
-
 	}
-
 }

--- a/includes/forms/class-wpum-form-password-recovery.php
+++ b/includes/forms/class-wpum-form-password-recovery.php
@@ -89,7 +89,6 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 		) );
 
 		$this->sort_set_steps();
-
 	}
 
 	/**
@@ -148,7 +147,6 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 		if ( isset( $_GET['user_id'] ) && isset( $_GET['key'] ) && isset( $_GET['step'] ) && 'reset' === $_GET['step'] ) { // phpcs:ignore
 			unset( $this->fields['user'] );
 		}
-
 	}
 
 	/**
@@ -199,7 +197,6 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 		WPUM()->templates
 			->set_template_data( $atts )
 			->get_template_part( 'action-links' );
-
 	}
 
 	/**
@@ -267,7 +264,7 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 			}
 
 			// Successful, show next step.
-			$this->step ++;
+			++$this->step;
 
 		} catch ( Exception $e ) {
 			$this->add_error( $e->getMessage(), 'password_recovery_submit' );
@@ -300,7 +297,6 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 		WPUM()->templates
 			->set_template_data( $data )
 			->get_template_part( 'messages/password-reset', 'request-success' );
-
 	}
 
 	/**
@@ -357,7 +353,6 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 				->get_template_part( 'messages/general', 'error' );
 
 		}
-
 	}
 
 	/**
@@ -459,13 +454,12 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 			$sessions->destroy_all();
 
 			// Successful, show next step.
-			$this->step ++;
+			++$this->step;
 
 		} catch ( Exception $e ) {
 			$this->add_error( $e->getMessage(), 'password_recovery_reset' );
 			return;
 		}
-
 	}
 
 	/**
@@ -483,7 +477,5 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 		WPUM()->templates
 			->set_template_data( $data )
 			->get_template_part( 'messages/general', 'success' );
-
 	}
-
 }

--- a/includes/forms/class-wpum-form-password.php
+++ b/includes/forms/class-wpum-form-password.php
@@ -83,7 +83,6 @@ class WPUM_Form_Password extends WPUM_Form {
 		);
 
 		$this->sort_set_steps();
-
 	}
 
 	/**
@@ -146,7 +145,6 @@ class WPUM_Form_Password extends WPUM_Form {
 		WPUM()->templates
 			->set_template_data( $data )
 			->get_template_part( 'forms/form', 'password' );
-
 	}
 
 	/**
@@ -184,7 +182,6 @@ class WPUM_Form_Password extends WPUM_Form {
 		}
 
 		return $pass;
-
 	}
 
 	/**
@@ -268,7 +265,5 @@ class WPUM_Form_Password extends WPUM_Form {
 			$this->add_error( $e->getMessage(), 'password_change_submit' );
 			return;
 		}
-
 	}
-
 }

--- a/includes/forms/class-wpum-form-privacy.php
+++ b/includes/forms/class-wpum-form-privacy.php
@@ -83,7 +83,6 @@ class WPUM_Form_Privacy extends WPUM_Form {
 		);
 
 		$this->sort_set_steps();
-
 	}
 
 	/**
@@ -136,7 +135,6 @@ class WPUM_Form_Privacy extends WPUM_Form {
 		WPUM()->templates
 			->set_template_data( $data )
 			->get_template_part( 'forms/form', 'privacy' );
-
 	}
 
 	/**
@@ -209,7 +207,5 @@ class WPUM_Form_Privacy extends WPUM_Form {
 			$this->add_error( $e->getMessage(), 'privacy_submit' );
 			return;
 		}
-
 	}
-
 }

--- a/includes/forms/class-wpum-form-profile.php
+++ b/includes/forms/class-wpum-form-profile.php
@@ -88,7 +88,6 @@ class WPUM_Form_Profile extends WPUM_Form {
 		);
 
 		$this->sort_set_steps();
-
 	}
 
 	/**
@@ -105,7 +104,6 @@ class WPUM_Form_Profile extends WPUM_Form {
 				'account' => $this->get_account_fields(),
 			)
 		);
-
 	}
 
 	/**
@@ -136,7 +134,6 @@ class WPUM_Form_Profile extends WPUM_Form {
 		}
 
 		return $pass;
-
 	}
 
 	/**
@@ -160,7 +157,7 @@ class WPUM_Form_Profile extends WPUM_Form {
 
 		foreach ( $account_fields as $field ) {
 
-			$priority ++;
+			++$priority;
 
 			$field = new WPUM_Field( $field );
 
@@ -208,7 +205,6 @@ class WPUM_Form_Profile extends WPUM_Form {
 		}
 
 		return $fields;
-
 	}
 
 	/**
@@ -231,7 +227,6 @@ class WPUM_Form_Profile extends WPUM_Form {
 		WPUM()->templates
 			->set_template_data( $data )
 			->get_template_part( 'forms/form', 'account' );
-
 	}
 
 
@@ -301,7 +296,6 @@ class WPUM_Form_Profile extends WPUM_Form {
 			$this->add_error( $e->getMessage(), 'account_handler' );
 			return;
 		}
-
 	}
 
 	/**
@@ -334,6 +328,5 @@ class WPUM_Form_Profile extends WPUM_Form {
 		}
 
 		return $name;
-
 	}
 }

--- a/includes/forms/class-wpum-form-registration.php
+++ b/includes/forms/class-wpum-form-registration.php
@@ -182,7 +182,6 @@ class WPUM_Form_Registration extends WPUM_Form {
 		}
 
 		return $pass;
-
 	}
 
 	/**
@@ -203,7 +202,6 @@ class WPUM_Form_Registration extends WPUM_Form {
 		}
 
 		return $pass;
-
 	}
 
 	/**
@@ -292,7 +290,6 @@ class WPUM_Form_Registration extends WPUM_Form {
 		}
 
 		$this->fields = array( 'register' => $this->get_registration_fields() );
-
 	}
 
 	/**
@@ -446,7 +443,6 @@ class WPUM_Form_Registration extends WPUM_Form {
 		}
 
 		return $by;
-
 	}
 
 	/**
@@ -492,7 +488,6 @@ class WPUM_Form_Registration extends WPUM_Form {
 			WPUM()->templates->set_template_data( array( 'message' => sprintf( __( 'The registration form cannot be used because either a username or email field is required to process registrations. Please edit the form and add at least the email field. <a href="%1$s">%2$s</a>', 'wp-user-manager' ), esc_url_raw( $admin_url ), $admin_url ) ) )->get_template_part( 'messages/general', 'error' );
 
 		}
-
 	}
 
 	/**
@@ -607,7 +602,7 @@ class WPUM_Form_Registration extends WPUM_Form {
 			}
 
 			// Successful, show next step.
-			$this->step ++;
+			++$this->step;
 
 		} catch ( Exception $e ) {
 			$this->add_error( $e->getMessage(), 'registration_submit' );
@@ -666,7 +661,7 @@ class WPUM_Form_Registration extends WPUM_Form {
 				$template     = isset( $field['template'] ) ? $field['template'] : $field['type'];
 
 				WPUM()->templates->set_template_data( $field )
-								 ->get_template_part( 'form-fields/' . $template, 'field' );
+								->get_template_part( 'form-fields/' . $template, 'field' );
 
 				return;
 			}
@@ -676,8 +671,7 @@ class WPUM_Form_Registration extends WPUM_Form {
 				'key'     => $key,
 				'form_id' => $this->form_id,
 			) )
-							 ->get_template_part( 'forms/form-registration-fields', 'field' );
+							->get_template_part( 'forms/form-registration-fields', 'field' );
 		}
 	}
-
 }

--- a/includes/forms/class-wpum-registration-form.php
+++ b/includes/forms/class-wpum-registration-form.php
@@ -91,7 +91,6 @@ class WPUM_Registration_Form {
 		} else {
 			return false;
 		}
-
 	}
 
 	/**

--- a/includes/forms/class-wpum-registration-forms-editor.php
+++ b/includes/forms/class-wpum-registration-forms-editor.php
@@ -131,7 +131,6 @@ class WPUM_Registration_Forms_Editor {
 
 			wp_localize_script( 'wpum-registration-forms-editor', 'wpumRegistrationFormsEditor', $js_variables );
 		}
-
 	}
 
 	/**
@@ -220,7 +219,6 @@ class WPUM_Registration_Forms_Editor {
 		} else {
 			$this->send_json_error();
 		}
-
 	}
 
 	/**
@@ -305,7 +303,6 @@ class WPUM_Registration_Forms_Editor {
 			$this->send_json_error();
 
 		}
-
 	}
 
 	/**
@@ -354,7 +351,6 @@ class WPUM_Registration_Forms_Editor {
 		}
 
 		return $fields;
-
 	}
 
 	/**
@@ -453,7 +449,6 @@ class WPUM_Registration_Forms_Editor {
 			$this->send_json_error();
 
 		}
-
 	}
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -169,7 +169,6 @@ function wpum_get_core_page_id( $page = null ) {
 	$id = is_array( $id ) ? $id[0] : false;
 
 	return $id;
-
 }
 
 /**
@@ -198,10 +197,8 @@ function wpum_list_pluck( $list, $field, $index_key = null ) {
 				if ( isset( $value->$field ) ) {
 					$list[ $key ] = $value->$field;
 				}
-			} else {
-				if ( isset( $value[ $field ] ) ) {
+			} elseif ( isset( $value[ $field ] ) ) {
 					$list[ $key ] = $value[ $field ];
-				}
 			}
 		}
 
@@ -220,12 +217,10 @@ function wpum_list_pluck( $list, $field, $index_key = null ) {
 			} else {
 				$newlist[] = $value->$field;
 			}
-		} else {
-			if ( isset( $value[ $index_key ] ) ) {
+		} elseif ( isset( $value[ $index_key ] ) ) {
 				$newlist[ $value[ $index_key ] ] = $value[ $field ];
-			} else {
-				$newlist[] = $value[ $field ];
-			}
+		} else {
+			$newlist[] = $value[ $field ];
 		}
 	}
 	$list = $newlist;
@@ -250,7 +245,6 @@ function wpum_get_login_label() {
 	}
 
 	return $label;
-
 }
 
 /**
@@ -344,7 +338,6 @@ function wpum_mask_email_address( $email_address ) {
 	$d   = implode( '.', $d );
 
 	return wpum_starmid( $u ) . '@' . wpum_starmid( $d ) . ".$tld";
-
 }
 
 /**
@@ -400,7 +393,6 @@ function wpum_log_user_in( $email_or_id ) {
 	wp_set_current_user( $user_id, $username );
 	wp_set_auth_cookie( $user_id );
 	do_action( 'wp_login', $username, $user );
-
 }
 
 /**
@@ -748,7 +740,6 @@ function wpum_get_account_page_tabs() {
 	uasort( $tabs, 'wpum_sort_array_by_priority' );
 
 	return $tabs;
-
 }
 
 /**
@@ -776,7 +767,6 @@ function wpum_get_full_page_hierarchy( $page_id ) {
 	}
 
 	return $return;
-
 }
 
 /**
@@ -820,7 +810,6 @@ function wpum_get_queried_user() {
 	$queried_user = get_query_var( 'profile', false );
 
 	return $queried_user;
-
 }
 
 /**
@@ -864,7 +853,6 @@ function wpum_get_queried_user_id() {
 	}
 
 	return $user_id;
-
 }
 
 /**
@@ -902,7 +890,6 @@ function wpum_get_profile_url( $user ) {
 	}
 
 	return $page_url;
-
 }
 
 /**
@@ -939,7 +926,6 @@ function wpum_get_registered_profile_tabs() {
 	uasort( $tabs, 'wpum_sort_array_by_priority' );
 
 	return $tabs;
-
 }
 
 /**
@@ -1044,7 +1030,6 @@ function wpum_get_comments_for_profile( $user_id ) {
 	$comments['items']   = get_comments( $args );
 
 	return $comments;
-
 }
 
 /**
@@ -1211,7 +1196,6 @@ function wpum_custom_admin_notice_inline_css() {
 		}
 	</style>
 	<?php
-
 }
 
 /**
@@ -1233,7 +1217,6 @@ function wpum_setup_default_custom_search_fields() {
 			'meta_key' => 'last_name',
 		)
 	);
-
 }
 
 /**
@@ -1279,7 +1262,6 @@ function wpum_get_mime_types_for_selection() {
 	}
 
 	return $types;
-
 }
 
 if ( ! function_exists( 'wp_new_user_notification' ) ) {

--- a/includes/install.php
+++ b/includes/install.php
@@ -34,7 +34,6 @@ function wp_user_manager_install( $network_wide = false ) {
 	} else {
 		wpum_run_install();
 	}
-
 }
 
 /**
@@ -156,7 +155,6 @@ function wpum_install_registration_form( $fields = array() ) {
 	}
 
 	$default_form->add_meta( 'fields', $default_fields );
-
 }
 
 /**
@@ -267,7 +265,6 @@ function wpum_run_install() {
 
 	// Add the transient to redirect.
 	set_transient( '_wpum_activation_redirect', true, 30 );
-
 }
 
 /**

--- a/includes/integrations/stripe/Account.php
+++ b/includes/integrations/stripe/Account.php
@@ -75,7 +75,6 @@ class Account {
 
 		add_action( 'template_redirect', array( $this, 'handle_download_invoice' ) );
 		add_action( 'wpum_account_page_content', array( $this, 'render_payment_message' ), 9 );
-
 	}
 
 	/**

--- a/includes/integrations/stripe/Controllers/Products.php
+++ b/includes/integrations/stripe/Controllers/Products.php
@@ -148,11 +148,10 @@ class Products {
 		$products = $this->all();
 		foreach ( $products as $product ) {
 			if ( 'one_time' !== $product['type'] ) {
-				$total ++;
+				++$total;
 			}
 		}
 
 		return $total;
 	}
-
 }

--- a/includes/integrations/stripe/InvoiceLineItem.php
+++ b/includes/integrations/stripe/InvoiceLineItem.php
@@ -9,8 +9,8 @@
 
 namespace WPUserManager\Stripe;
 
-use \WPUM\Carbon\Carbon;
-use \WPUM\Stripe\InvoiceLineItem as StripeInvoiceLineItem;
+use WPUM\Carbon\Carbon;
+use WPUM\Stripe\InvoiceLineItem as StripeInvoiceLineItem;
 
 /**
  * InvoiceLineItem

--- a/includes/integrations/stripe/Models/Invoice.php
+++ b/includes/integrations/stripe/Models/Invoice.php
@@ -63,5 +63,4 @@ class Invoice {
 
 		$this->customer = new User( $this->user_id );
 	}
-
 }

--- a/includes/integrations/stripe/Models/Product.php
+++ b/includes/integrations/stripe/Models/Product.php
@@ -98,4 +98,3 @@ class Product {
 		$this->when_paid = time();
 	}
 }
-

--- a/includes/integrations/stripe/Models/Subscription.php
+++ b/includes/integrations/stripe/Models/Subscription.php
@@ -77,7 +77,7 @@ class Subscription {
 	 * @return bool
 	 */
 	public function onTrial() {
-		 return $this->trial_ends_at && $this->trial_ends_at > current_time( 'mysql' );
+		return $this->trial_ends_at && $this->trial_ends_at > current_time( 'mysql' );
 	}
 
 	/**
@@ -100,7 +100,7 @@ class Subscription {
 	 * @return bool
 	 */
 	public function expired() {
-		 return $this->cancelled() && ! $this->onGracePeriod();
+		return $this->cancelled() && ! $this->onGracePeriod();
 	}
 
 	/**

--- a/includes/integrations/stripe/Models/User.php
+++ b/includes/integrations/stripe/Models/User.php
@@ -64,7 +64,7 @@ class User extends \WP_User {
 	 * @return bool
 	 */
 	public function isAdmin() {
-		 return $this->has_cap( 'administrator' );
+		return $this->has_cap( 'administrator' );
 	}
 
 	/**

--- a/includes/integrations/stripe/Registration.php
+++ b/includes/integrations/stripe/Registration.php
@@ -194,7 +194,7 @@ class Registration {
 
 			$user = new User( $new_user_id );
 			$user->setPlanMeta( $product->to_array() );
-		};
+		}
 	}
 
 	/**

--- a/includes/integrations/stripe/WebhookEndpoint.php
+++ b/includes/integrations/stripe/WebhookEndpoint.php
@@ -62,5 +62,4 @@ class WebhookEndpoint {
 			'permission_callback' => '__return_true',
 		) );
 	}
-
 }

--- a/includes/roles/class-wpum-roles-editor.php
+++ b/includes/roles/class-wpum-roles-editor.php
@@ -116,7 +116,6 @@ class WPUM_Roles_Editor {
 
 			wp_localize_script( 'wpum-roles-editor', 'wpumRolesEditor', $js_variables );
 		}
-
 	}
 
 	/**
@@ -396,7 +395,6 @@ class WPUM_Roles_Editor {
 		do_action( 'wpum_role_delete', $role_id );
 
 		wp_send_json_success( (string) $role_id );
-
 	}
 
 	/**
@@ -467,7 +465,6 @@ class WPUM_Roles_Editor {
 		} else {
 			wp_die( esc_html__( 'Something went wrong: could not create new role.', 'wp-user-manager' ), 403 );
 		}
-
 	}
 
 	/**
@@ -489,7 +486,6 @@ class WPUM_Roles_Editor {
 	private function send_json_error() {
 		wp_send_json_error( null, 403 );
 	}
-
 }
 
 $wpum_roles_editor = new WPUM_Roles_Editor();

--- a/includes/roles/functions.php
+++ b/includes/roles/functions.php
@@ -310,7 +310,6 @@ function wpum_register_caps() {
 	foreach ( $unregistered as $cap ) {
 		wpum_register_cap( $cap, array( 'label' => $cap ) );
 	}
-
 }
 
 /**

--- a/includes/shortcodes/class-wpum-shortcode-button.php
+++ b/includes/shortcodes/class-wpum-shortcode-button.php
@@ -105,8 +105,8 @@ final class WPUM_Shortcode_Button {
 
 		// Only run in admin post/page creation and edit screens
 		if ( in_array( $screen->parent_file, $shortcode_button_pages, true )
-			 && apply_filters( 'wpum_shortcode_button_condition', true )
-			 && ! empty( self::$shortcodes )
+			&& apply_filters( 'wpum_shortcode_button_condition', true )
+			&& ! empty( self::$shortcodes )
 		) {
 			$shortcodes = array();
 			foreach ( self::$shortcodes as $shortcode => $values ) {
@@ -176,7 +176,6 @@ final class WPUM_Shortcode_Button {
 		}
 		wp_send_json( $response );
 	}
-
 }
 
 new WPUM_Shortcode_Button();

--- a/includes/shortcodes/class-wpum-shortcode-content-loggedin.php
+++ b/includes/shortcodes/class-wpum-shortcode-content-loggedin.php
@@ -41,7 +41,6 @@ class WPUM_Shortcode_Content_Loggedin extends WPUM_Shortcode_Generator {
 			),
 		);
 	}
-
 }
 
 new WPUM_Shortcode_Content_Loggedin();

--- a/includes/shortcodes/class-wpum-shortcode-content-loggedout.php
+++ b/includes/shortcodes/class-wpum-shortcode-content-loggedout.php
@@ -41,7 +41,6 @@ class WPUM_Shortcode_Content_Loggedout extends WPUM_Shortcode_Generator {
 			),
 		);
 	}
-
 }
 
 new WPUM_Shortcode_Content_Loggedout();

--- a/includes/shortcodes/class-wpum-shortcode-content-roles.php
+++ b/includes/shortcodes/class-wpum-shortcode-content-roles.php
@@ -47,7 +47,6 @@ class WPUM_Shortcode_Content_Roles extends WPUM_Shortcode_Generator {
 			),
 		);
 	}
-
 }
 
 new WPUM_Shortcode_Content_Roles();

--- a/includes/shortcodes/class-wpum-shortcode-content-users.php
+++ b/includes/shortcodes/class-wpum-shortcode-content-users.php
@@ -47,7 +47,6 @@ class WPUM_Shortcode_Content_Users extends WPUM_Shortcode_Generator {
 			),
 		);
 	}
-
 }
 
 new WPUM_Shortcode_Content_Users();

--- a/includes/shortcodes/class-wpum-shortcode-directory.php
+++ b/includes/shortcodes/class-wpum-shortcode-directory.php
@@ -40,7 +40,6 @@ class WPUM_Shortcode_Directory extends WPUM_Shortcode_Generator {
 			),
 		);
 	}
-
 }
 
 new WPUM_Shortcode_Directory();

--- a/includes/shortcodes/class-wpum-shortcode-login-link.php
+++ b/includes/shortcodes/class-wpum-shortcode-login-link.php
@@ -47,7 +47,6 @@ class WPUM_Shortcode_Login_Link extends WPUM_Shortcode_Generator {
 			),
 		);
 	}
-
 }
 
 new WPUM_Shortcode_Login_Link();

--- a/includes/shortcodes/class-wpum-shortcode-login.php
+++ b/includes/shortcodes/class-wpum-shortcode-login.php
@@ -47,7 +47,6 @@ class WPUM_Shortcode_Login extends WPUM_Shortcode_Generator {
 			),
 		);
 	}
-
 }
 
 new WPUM_Shortcode_Login();

--- a/includes/shortcodes/class-wpum-shortcode-logout-link.php
+++ b/includes/shortcodes/class-wpum-shortcode-logout-link.php
@@ -47,7 +47,6 @@ class WPUM_Shortcode_Logout_Link extends WPUM_Shortcode_Generator {
 			),
 		);
 	}
-
 }
 
 new WPUM_Shortcode_Logout_Link();

--- a/includes/shortcodes/class-wpum-shortcode-my-account.php
+++ b/includes/shortcodes/class-wpum-shortcode-my-account.php
@@ -25,7 +25,6 @@ class WPUM_Shortcode_My_Account extends WPUM_Shortcode_Generator {
 		$this->shortcode['label'] = esc_html__( 'Account page', 'wp-user-manager' );
 		parent::__construct( 'wpum_account' );
 	}
-
 }
 
 new WPUM_Shortcode_My_Account();

--- a/includes/shortcodes/class-wpum-shortcode-password.php
+++ b/includes/shortcodes/class-wpum-shortcode-password.php
@@ -47,7 +47,6 @@ class WPUM_Shortcode_Password extends WPUM_Shortcode_Generator {
 			),
 		);
 	}
-
 }
 
 new WPUM_Shortcode_Password();

--- a/includes/shortcodes/class-wpum-shortcode-profile-card.php
+++ b/includes/shortcodes/class-wpum-shortcode-profile-card.php
@@ -59,7 +59,6 @@ class WPUM_Shortcode_Profile_Card extends WPUM_Shortcode_Generator {
 			),
 		);
 	}
-
 }
 
 new WPUM_Shortcode_Profile_Card();

--- a/includes/shortcodes/class-wpum-shortcode-profile.php
+++ b/includes/shortcodes/class-wpum-shortcode-profile.php
@@ -25,7 +25,6 @@ class WPUM_Shortcode_Profile extends WPUM_Shortcode_Generator {
 		$this->shortcode['label'] = esc_html__( 'Profiles page', 'wp-user-manager' );
 		parent::__construct( 'wpum_profile' );
 	}
-
 }
 
 new WPUM_Shortcode_Profile();

--- a/includes/shortcodes/class-wpum-shortcode-recently-registered.php
+++ b/includes/shortcodes/class-wpum-shortcode-recently-registered.php
@@ -47,7 +47,6 @@ class WPUM_Shortcode_Recently_Registered extends WPUM_Shortcode_Generator {
 			),
 		);
 	}
-
 }
 
 new WPUM_Shortcode_Recently_Registered();

--- a/includes/shortcodes/class-wpum-shortcode-registration.php
+++ b/includes/shortcodes/class-wpum-shortcode-registration.php
@@ -47,7 +47,6 @@ class WPUM_Shortcode_Registration extends WPUM_Shortcode_Generator {
 			),
 		);
 	}
-
 }
 
 new WPUM_Shortcode_Registration();

--- a/includes/shortcodes/shortcodes.php
+++ b/includes/shortcodes/shortcodes.php
@@ -50,7 +50,6 @@ function wpum_login_form( $atts, $content = null ) {
 	$output = ob_get_clean();
 
 	return $output;
-
 }
 add_shortcode( 'wpum_login_form', 'wpum_login_form' );
 
@@ -86,7 +85,6 @@ function wpum_password_recovery( $atts, $content = null ) {
 	$output = ob_get_clean();
 
 	return $output;
-
 }
 add_shortcode( 'wpum_password_recovery', 'wpum_password_recovery' );
 
@@ -228,7 +226,6 @@ function wpum_registration_form( $atts, $content = null ) {
 	$output = ob_get_clean();
 
 	return $output;
-
 }
 add_shortcode( 'wpum_register', 'wpum_registration_form' );
 
@@ -251,7 +248,6 @@ function wpum_account_page( $atts, $content = null ) {
 	$output = ob_get_clean();
 
 	return $output;
-
 }
 add_shortcode( 'wpum_account', 'wpum_account_page' );
 
@@ -320,9 +316,8 @@ function wpum_profile( $atts, $content = null ) {
 			)
 			->get_template_part( 'messages/general', 'warning' );
 
-	} else {
+	} elseif ( ! $queried_user_id ) {
 
-		if ( ! $queried_user_id ) {
 			WPUM()->templates
 				->set_template_data(
 					array(
@@ -330,22 +325,20 @@ function wpum_profile( $atts, $content = null ) {
 					)
 				)
 				->get_template_part( 'messages/general', 'warning' );
-		} else {
-			WPUM()->templates
-				->set_template_data(
-					array(
-						'user'            => get_user_by( 'id', $queried_user_id ),
-						'current_user_id' => get_current_user_id(),
-					)
+	} else {
+		WPUM()->templates
+			->set_template_data(
+				array(
+					'user'            => get_user_by( 'id', $queried_user_id ),
+					'current_user_id' => get_current_user_id(),
 				)
-				->get_template_part( 'profile' );
-		}
+			)
+			->get_template_part( 'profile' );
 	}
 
 	$output = ob_get_clean();
 
 	return $output;
-
 }
 add_shortcode( 'wpum_profile', 'wpum_profile' );
 
@@ -548,7 +541,6 @@ function wpum_restrict_to_users( $atts, $content = null ) {
 	$output = ob_get_clean();
 
 	return $output;
-
 }
 add_shortcode( 'wpum_restrict_to_users', 'wpum_restrict_to_users' );
 
@@ -711,7 +703,6 @@ function wpum_profile_card( $atts, $content = null ) {
 	$output = ob_get_clean();
 
 	return $output;
-
 }
 add_shortcode( 'wpum_profile_card', 'wpum_profile_card' );
 
@@ -943,7 +934,6 @@ function wpum_directory( $atts, $content = null ) {
 	wp_enqueue_script( 'wpum-directories' );
 
 	return $output;
-
 }
 add_shortcode( 'wpum_user_directory', 'wpum_directory' );
 

--- a/includes/updates/class-wpum-license.php
+++ b/includes/updates/class-wpum-license.php
@@ -111,7 +111,6 @@ class WPUM_License {
 
 		$this->includes();
 		$this->hooks();
-
 	}
 
 	/**
@@ -122,7 +121,6 @@ class WPUM_License {
 		if ( ! class_exists( 'WPUM_EDD_SL_Plugin_Updater' ) ) {
 			require_once WPUM_PLUGIN_DIR . 'includes/updates/WPUM_EDD_SL_Plugin_Updater.php';
 		}
-
 	}
 
 	/**
@@ -163,7 +161,7 @@ class WPUM_License {
 
 		// translators: %1$s wpum addon name
 		$new_settings[] = Field::make( 'text', $this->item_shortname . '_license_key', sprintf( __( '%1$s License Key', 'wp-user-manager' ), $this->item_name ) )
-							   ->set_help_text( $this->get_status_notice( $status, $expires ) );
+								->set_help_text( $this->get_status_notice( $status, $expires ) );
 
 		return array_merge( $settings, $new_settings );
 	}
@@ -269,7 +267,6 @@ class WPUM_License {
 		}
 
 		return json_decode( wp_remote_retrieve_body( $response ) );
-
 	}
 
 	/**
@@ -650,5 +647,4 @@ class WPUM_License {
 
 		return $message;
 	}
-
 }

--- a/includes/updates/class-wpum-updater-settings.php
+++ b/includes/updates/class-wpum-updater-settings.php
@@ -55,7 +55,6 @@ class WPUM_Updater_Settings {
 			->set_page_file( 'wpum-licenses' )
 			->add_fields( $settings );
 		}
-
 	}
 
 	/**
@@ -72,7 +71,6 @@ class WPUM_Updater_Settings {
 		}
 
 		return $settings;
-
 	}
 
 	/**
@@ -104,7 +102,6 @@ class WPUM_Updater_Settings {
 			<?php
 
 		}
-
 	}
 
 	/**
@@ -155,9 +152,7 @@ class WPUM_Updater_Settings {
 			window.wpum_removeArguments();
 		</script>
 		<?php
-
 	}
-
 }
 
 new WPUM_Updater_Settings();

--- a/includes/updates/free-plugins.php
+++ b/includes/updates/free-plugins.php
@@ -60,5 +60,4 @@ function wpum_free_plugins_auto_updater() {
 			'url'       => home_url(),
 		) );
 	}
-
 }

--- a/includes/widgets/class-wpum-login-form-widget.php
+++ b/includes/widgets/class-wpum-login-form-widget.php
@@ -85,7 +85,6 @@ class WPUM_Login_Form_Widget extends \WPUM\WPH_Widget {
 
 		// create widget
 		$this->create_widget( $args );
-
 	}
 
 	/**
@@ -128,5 +127,4 @@ class WPUM_Login_Form_Widget extends \WPUM\WPH_Widget {
 
 		echo wp_kses_post( $args['after_widget'] );
 	}
-
 }

--- a/includes/widgets/class-wpum-password-recovery.php
+++ b/includes/widgets/class-wpum-password-recovery.php
@@ -47,7 +47,6 @@ class WPUM_Password_Recovery extends \WPUM\WPH_Widget {
 
 		// create widget
 		$this->create_widget( $args );
-
 	}
 
 	/**
@@ -72,5 +71,4 @@ class WPUM_Password_Recovery extends \WPUM\WPH_Widget {
 
 		echo wp_kses_post( $args['after_widget'] );
 	}
-
 }

--- a/includes/widgets/class-wpum-recently-registered-users.php
+++ b/includes/widgets/class-wpum-recently-registered-users.php
@@ -65,7 +65,6 @@ class WPUM_Recently_Registered_Users extends \WPUM\WPH_Widget {
 
 		// create widget
 		$this->create_widget( $args );
-
 	}
 
 	/**
@@ -101,7 +100,5 @@ class WPUM_Recently_Registered_Users extends \WPUM\WPH_Widget {
 		echo wp_kses_post( $output );
 
 		echo wp_kses_post( $args['after_widget'] );
-
 	}
-
 }

--- a/includes/widgets/class-wpum-registration-form-widget.php
+++ b/includes/widgets/class-wpum-registration-form-widget.php
@@ -61,7 +61,6 @@ class WPUM_Registration_Form_Widget extends \WPUM\WPH_Widget {
 
 		// create widget
 		$this->create_widget( $args );
-
 	}
 
 	/**
@@ -88,5 +87,4 @@ class WPUM_Registration_Form_Widget extends \WPUM\WPH_Widget {
 
 		echo wp_kses_post( $args['after_widget'] );
 	}
-
 }

--- a/templates/already-logged-in.php
+++ b/templates/already-logged-in.php
@@ -47,7 +47,7 @@ $counter = 0;
 		?>
 		<?php
 		foreach ( $links as $template_link ) :
-			$counter ++;
+			++$counter;
 			?>
 			<a href="<?php echo esc_url( $template_link['url'] ); ?>"><?php echo esc_html( $template_link['text'] ); ?></a> <?php echo $counter < $count ? '|' : ''; ?>
 		<?php endforeach; ?>

--- a/templates/directory/top-bar.php
+++ b/templates/directory/top-bar.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="wpum-col-xs">
 			<?php
 			// translators: %s count of users
-			echo sprintf( esc_html__( 'Found %s users.', 'wp-user-manager' ), absint( $data->total ) );
+			printf( esc_html__( 'Found %s users.', 'wp-user-manager' ), absint( $data->total ) );
 			?>
 		</div>
 

--- a/templates/emails/footer-default.php
+++ b/templates/emails/footer-default.php
@@ -53,7 +53,7 @@ $credit = "
 												<table border="0" cellpadding="10" cellspacing="0" width="100%">
 													<tr>
 														<td colspan="2" valign="middle" id="credit" style="<?php echo $credit; // phpcs:ignore  ?>">
-														   <?php echo wp_kses_post( wpautop( wptexturize( apply_filters( 'wpum_email_footer_text', '<a style="color:#000;" href="' . esc_url( home_url() ) . '">' . get_bloginfo( 'name' ) . '</a>' ) ) ) ); ?>
+															<?php echo wp_kses_post( wpautop( wptexturize( apply_filters( 'wpum_email_footer_text', '<a style="color:#000;" href="' . esc_url( home_url() ) . '">' . get_bloginfo( 'name' ) . '</a>' ) ) ) ); ?>
 														</td>
 													</tr>
 												</table>

--- a/templates/form-fields/checkbox-field.php
+++ b/templates/form-fields/checkbox-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -21,11 +21,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <input type="checkbox" class="input-checkbox" name="<?php echo esc_attr( isset( $data->name ) ? $data->name : $data->key ); ?>" id="<?php echo esc_attr( $data->key ); ?>" <?php checked( ! empty( $data->value ), true ); ?> value="1"
-															   <?php
+																<?php
 																if ( ! empty( $data->required ) ) {
 																	echo 'required';}
 																?>
- />
+/>
 <?php
 if ( ! empty( $data->description ) ) :
 	?>

--- a/templates/form-fields/complex-field.php
+++ b/templates/form-fields/complex-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -33,7 +33,7 @@ $fields = WPUM()->fields->get_fields(array(
 
 $parent_key = $parent->get_key();
 
-echo sprintf(
+printf(
 	'<fieldset class="fieldset-%s"><legend>%s %s</legend>',
 	esc_attr( $parent_key ),
 	esc_html( $data->label ),
@@ -45,7 +45,7 @@ $max_rows     = $parent->get_meta( 'max_rows' );
 
 if ( count( $fields ) ) {
 
-	$field_keys = array_map( function( $field ) {
+	$field_keys = array_map( function ( $field ) {
 			return $field->get_key();
 	}, $fields );
 
@@ -71,7 +71,7 @@ if ( count( $fields ) ) {
 		$clone_row = (int) $index === (int) $clone_row_index;
 		echo '<div class="fieldset-wpum_field_group' . ( $clone_row ? ' fieldset-wpum_field_group-clone' : '' ) . '">';
 
-		echo sprintf(
+		printf(
 			'<a href="#" class="remove-repeater-row" title="%s">x</a>',
 			esc_html__( 'Remove', 'wp-user-manager' )
 		);
@@ -126,7 +126,7 @@ if ( count( $fields ) ) {
 
 		echo '</div>';
 
-		$index++;
+		++$index;
 
 	} while ( isset( $values[ $index ] ) );
 }
@@ -134,7 +134,7 @@ if ( count( $fields ) ) {
 $max_rows     = ! empty( $max_rows ) ? intval( $max_rows ) : 0;
 $button_label = ! empty( $button_label ) ? $button_label : __( 'Add row', 'wp-user-manager' );
 
-echo sprintf(
+printf(
 	'<button type="button" class="add-repeater-row" data-max-row="%d">%s</button>',
 	esc_attr( $max_rows ),
 	esc_html( $button_label )

--- a/templates/form-fields/datepicker-field.php
+++ b/templates/form-fields/datepicker-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/templates/form-fields/dropdown-field.php
+++ b/templates/form-fields/dropdown-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -21,18 +21,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <select name="<?php echo esc_attr( isset( $data->name ) ? $data->name : $data->key ); ?>" id="<?php echo esc_attr( $data->key ); ?>"
-						 <?php
-							if ( ! empty( $data->required ) ) {
-								echo 'required';}
-							?>
- <?php
-	if ( ! empty( $data->read_only ) ) {
-		echo 'disabled';}
-	?>
+						<?php
+						if ( ! empty( $data->required ) ) {
+							echo 'required';}
+						?>
+<?php
+if ( ! empty( $data->read_only ) ) {
+	echo 'disabled';}
+?>
 >
 	<?php foreach ( $data->options as $key => $value ) : ?>
 		<option value="<?php echo esc_attr( $key ); ?>"
-								  <?php
+									<?php
 									if ( isset( $data->value ) || isset( $data->default ) ) {
 										selected( isset( $data->value ) ? $data->value : $data->default, $key );}
 									?>

--- a/templates/form-fields/email-field.php
+++ b/templates/form-fields/email-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/templates/form-fields/file-field.php
+++ b/templates/form-fields/file-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -31,7 +31,7 @@ if ( ! empty( $data->ajax ) && wpum_user_can_upload_file_via_ajax() ) {
 ?>
 
 <div class="wpum-uploaded-files">
-  <?php
+	<?php
 	if ( ! empty( $data->value ) ) :
 		if ( is_array( $data->value ) ) :
 			if ( isset( $data->value['url'] ) ) :
@@ -52,7 +52,7 @@ if ( ! empty( $data->ajax ) && wpum_user_can_upload_file_via_ajax() ) {
 				'field' => array(),
 			) )->get_template_part( 'form-fields/file', 'uploaded' );
 		endif;
-  endif;
+	endif;
 	?>
 </div>
 
@@ -66,9 +66,9 @@ if ( ! empty( $data->multiple ) ) {
 <small class="description">
 <?php
 if ( ! empty( $data->description ) ) :
-		 echo esc_html( $data->description );
+		echo esc_html( $data->description );
 		endif;
 		// translators: %s Maximum file size
-	  echo sprintf( esc_html__( 'Maximum file size: %s.', 'wp-user-manager' ), esc_html( wpum_max_upload_size( isset( $data->key ) ? $data->key : '', $file_size ) ) );
+		printf( esc_html__( 'Maximum file size: %s.', 'wp-user-manager' ), esc_html( wpum_max_upload_size( isset( $data->key ) ? $data->key : '', $file_size ) ) );
 ?>
 </small>

--- a/templates/form-fields/file-uploaded.php
+++ b/templates/form-fields/file-uploaded.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/templates/form-fields/hidden-field.php
+++ b/templates/form-fields/hidden-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/templates/form-fields/multiselect-field.php
+++ b/templates/form-fields/multiselect-field.php
@@ -13,25 +13,25 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 ?>
 <select multiple="multiple" name="<?php echo esc_attr( isset( $data->name ) ? $data->name : $data->key ); ?>[]" id="<?php echo esc_attr( $data->key ); ?>" class="wpum-multiselect"
-											 <?php
-												if ( ! empty( $data->required ) ) {
-													echo 'required';}
-												?>
- <?php
-	if ( ! empty( $data->read_only ) ) {
-		echo 'disabled';}
-	?>
- placeholder="<?php echo empty( $data->placeholder ) ? '' : esc_attr( $data->placeholder ); ?>">
+											<?php
+											if ( ! empty( $data->required ) ) {
+												echo 'required';}
+											?>
+<?php
+if ( ! empty( $data->read_only ) ) {
+	echo 'disabled';}
+?>
+placeholder="<?php echo empty( $data->placeholder ) ? '' : esc_attr( $data->placeholder ); ?>">
 	<?php foreach ( $data->options as $key => $value ) : ?>
 		<option value="<?php echo esc_attr( $key ); ?>"
-								  <?php
+									<?php
 									if ( ! empty( $data->value ) && is_array( $data->value ) ) {
 										selected( in_array( $key, $data->value, true ), true );}
 									?>

--- a/templates/form-fields/number-field.php
+++ b/templates/form-fields/number-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/templates/form-fields/password-field.php
+++ b/templates/form-fields/password-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -25,12 +25,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( isset( $data->autocomplete ) && false === $data->autocomplete ) {
 	echo ' autocomplete="off"'; }
 ?>
- name="<?php echo esc_attr( isset( $data->name ) ? $data->name : $data->key ); ?>" id="<?php echo esc_attr( $data->key ); ?>" placeholder="<?php echo empty( $data->placeholder ) ? '' : esc_attr( $data->placeholder ); ?>" value="<?php echo isset( $data->value ) ? esc_attr( $data->value ) : ''; ?>" maxlength="<?php echo ! empty( $data->maxlength ) ? esc_attr( $data->maxlength ) : ''; ?>"
-				  <?php
+name="<?php echo esc_attr( isset( $data->name ) ? $data->name : $data->key ); ?>" id="<?php echo esc_attr( $data->key ); ?>" placeholder="<?php echo empty( $data->placeholder ) ? '' : esc_attr( $data->placeholder ); ?>" value="<?php echo isset( $data->value ) ? esc_attr( $data->value ) : ''; ?>" maxlength="<?php echo ! empty( $data->maxlength ) ? esc_attr( $data->maxlength ) : ''; ?>"
+					<?php
 					if ( ! empty( $data->required ) ) {
 						echo 'required';}
 					?>
-	 />
+	/>
 <?php
 if ( ! empty( $data->description ) ) :
 	?>

--- a/templates/form-fields/radio-field.php
+++ b/templates/form-fields/radio-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/templates/form-fields/select-field.php
+++ b/templates/form-fields/select-field.php
@@ -13,25 +13,25 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 ?>
 <select name="<?php echo esc_attr( isset( $data->name ) ? $data->name : $data->key ); ?>" id="<?php echo esc_attr( $data->key ); ?>"
-						 <?php
-							if ( ! empty( $data->required ) ) {
-								echo 'required';}
-							?>
- <?php
-	if ( ! empty( $data->read_only ) ) {
-		echo 'readonly';}
-	?>
+						<?php
+						if ( ! empty( $data->required ) ) {
+							echo 'required';}
+						?>
+<?php
+if ( ! empty( $data->read_only ) ) {
+	echo 'readonly';}
+?>
 >
 	<?php foreach ( $data->options as $key => $value ) : ?>
 		<option value="<?php echo esc_attr( $key ); ?>"
-								  <?php
+									<?php
 									if ( isset( $data->value ) || isset( $data->default ) ) {
 										selected( isset( $data->value ) ? $data->value : $data->default, $key );}
 									?>

--- a/templates/form-fields/taxonomy-field.php
+++ b/templates/form-fields/taxonomy-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/templates/form-fields/telephone-field.php
+++ b/templates/form-fields/telephone-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/templates/form-fields/text-field.php
+++ b/templates/form-fields/text-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/templates/form-fields/url-field.php
+++ b/templates/form-fields/url-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/templates/form-fields/user-field.php
+++ b/templates/form-fields/user-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/templates/form-fields/userrole-field.php
+++ b/templates/form-fields/userrole-field.php
@@ -13,7 +13,7 @@
  * @version 1.0.0
  */
 
- // Exit if accessed directly
+// Exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/templates/forms/form-registration.php
+++ b/templates/forms/form-registration.php
@@ -50,7 +50,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		$label = isset( $data->submit_label ) ? $data->submit_label : esc_html__( 'Register', 'wp-user-manager' );
 		?>
 		<input type="submit" name="submit_registration" class="button"
-			   value="<?php echo esc_html( apply_filters( 'wpum_registration_form_submit_label', $label ) ); ?>"/>
+				value="<?php echo esc_html( apply_filters( 'wpum_registration_form_submit_label', $label ) ); ?>"/>
 
 	</form>
 

--- a/templates/profiles/navigation.php
+++ b/templates/profiles/navigation.php
@@ -22,7 +22,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <nav class="profile-navbar">
 	<?php foreach ( $data->tabs as $tab_key => $data_tab ) : ?>
-		<a href="<?php echo esc_url( wpum_get_profile_tab_url( $data->user, $tab_key ) ); ?>" class="tab-<?php echo esc_attr( $tab_key ); ?> <?php
+		<a href="<?php echo esc_url( wpum_get_profile_tab_url( $data->user, $tab_key ) ); ?>" class="tab-<?php echo esc_attr( $tab_key ); ?>
+		<?php
 		if ( wpum_get_active_profile_tab() === $tab_key ) :
 			?>
 			active<?php endif; ?>"><?php echo esc_html( $data_tab['name'] ); ?></a>

--- a/wp-user-manager.php
+++ b/wp-user-manager.php
@@ -19,7 +19,7 @@
  * @return WP_User_Manager
  */
 function WPUM() {
-	require_once dirname( __FILE__ ) . '/includes/class-wp-user-manager.php';
+	require_once __DIR__ . '/includes/class-wp-user-manager.php';
 
 	return WP_User_Manager::instance( __FILE__, '2.9.13' );
 }


### PR DESCRIPTION
## Summary
- Ran `phpcbf` to auto-fix **391 violations** across 130 files from the WPCS 3.x upgrade
- Changes are formatting-only: whitespace, brace placement, `else if` → `elseif`, blank lines before closing braces
- **PHPStan still passes** with zero errors
- Remaining: 25 errors + 50 warnings that need manual review (separate PR)

## Test plan
- [ ] CI passes (PHPCS should show only the 75 remaining manual-fix violations)
- [ ] WPUnit tests pass (formatting changes only, no logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)