### PR TITLE
Fix remaining WPCS 3.x coding standard violations

### DIFF
--- a/includes/actions.php
+++ b/includes/actions.php
@@ -155,7 +155,7 @@ function wpum_restrict_wp_admin_dashboard_access() {
 		return;
 	}
 
-	if ( current_user_can( 'administrator' ) ) {
+	if ( current_user_can( 'manage_options' ) ) {
 		return;
 	}
 
@@ -220,7 +220,7 @@ function wpum_restrict_wp_profile() {
 
 	$profile_redirect = wpum_get_option( 'backend_profile_redirect' );
 
-	if ( ! current_user_can( 'administrator' ) && IS_PROFILE_PAGE && $profile_redirect ) {
+	if ( ! current_user_can( 'manage_options' ) && IS_PROFILE_PAGE && $profile_redirect ) {
 		wp_safe_redirect( esc_url( get_permalink( $profile_redirect[0] ) ) );
 		exit;
 	}
@@ -315,7 +315,7 @@ add_action( 'edit_user_profile_update', 'wpum_check_display_name' );
  *
  * @return void
  */
-function wpum_check_display_field( $errors, $update, $user ) {
+function wpum_check_display_field( $errors, $update, $user ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress user_profile_update_errors hook.
 	$errors->add( 'display_name_error', esc_html__( 'This display name is already in use by someone else. Display names must be unique.', 'wp-user-manager' ) );
 }
 
@@ -328,7 +328,7 @@ function wpum_check_display_field( $errors, $update, $user ) {
  *
  * @return void
  */
-function wpum_check_nick_field( $errors, $update, $user ) {
+function wpum_check_nick_field( $errors, $update, $user ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress user_profile_update_errors hook.
 	$errors->add( 'display_nick_error', esc_html__( 'This nickname is already in use by someone else. Nicknames must be unique.', 'wp-user-manager' ) );
 }
 
@@ -593,7 +593,7 @@ if ( is_multisite() ) {
 /**
  * @param \WP_User $user
  */
-function wpum_modify_multiple_roles_ui( $user ) {
+function wpum_modify_multiple_roles_ui( $user ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by WordPress hook signature.
 	$allow_multiple_roles = wpum_get_option( 'allow_multiple_user_roles' );
 	if ( ! $allow_multiple_roles ) {
 		return;

--- a/includes/admin/class-wpum-addons-page.php
+++ b/includes/admin/class-wpum-addons-page.php
@@ -87,7 +87,7 @@ class WPUM_Addons_Page {
 
 		$tab = filter_input( INPUT_GET, 'tab' );
 
-		if ( 'users_page_wpum-addons' === $screen->base || 'plugin-install' === $screen->base && 'wpum_addons' === $tab ) {
+		if ( 'users_page_wpum-addons' === $screen->base || ( 'plugin-install' === $screen->base && 'wpum_addons' === $tab ) ) {
 			wp_enqueue_style( 'wpum-addons', WPUM_PLUGIN_URL . 'assets/css/admin/addons.css', false, WPUM_VERSION );
 		}
 	}

--- a/includes/admin/class-wpum-avatars.php
+++ b/includes/admin/class-wpum-avatars.php
@@ -53,7 +53,7 @@ class WPUM_Avatars {
 
 				return $defaults;
 			} );
-			add_filter( 'pre_option_avatar_default', function ( $default ) {
+			add_filter( 'pre_option_avatar_default', function ( $default ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found, Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound -- Required by WordPress filter.
 				return 'wpum';
 			} );
 

--- a/includes/admin/class-wpum-menus.php
+++ b/includes/admin/class-wpum-menus.php
@@ -133,7 +133,7 @@ class WPUM_Menus {
 	 * @param array  $args
 	 * @return array
 	 */
-	public function set_nav_item_as_logout( $atts, $item, $args ) {
+	public function set_nav_item_as_logout( $atts, $item, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by nav_menu_link_attributes hook.
 
 		$is_logout = $this->is_nav_item_logout( $item );
 
@@ -153,7 +153,7 @@ class WPUM_Menus {
 	 *
 	 * @return array
 	 */
-	public function exclude_menu_items( $items, $menu, $args ) {
+	public function exclude_menu_items( $items, $menu, $args ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by wp_get_nav_menu_items hook.
 
 		foreach ( $items as $key => $item ) {
 
@@ -172,7 +172,7 @@ class WPUM_Menus {
 							$visible = false;
 						}
 
-						if ( current_user_can( 'administrator' ) && apply_filters( 'wpum_menu_restriction_allow_admins', true ) ) {
+						if ( current_user_can( 'manage_options' ) && apply_filters( 'wpum_menu_restriction_allow_admins', true ) ) {
 							$visible = true;
 						}
 					}

--- a/includes/admin/class-wpum-options-panel.php
+++ b/includes/admin/class-wpum-options-panel.php
@@ -77,7 +77,7 @@ class WPUM_Options_Panel {
 	 *
 	 * @return array
 	 */
-	public function setup_menu( $menu ) {
+	public function setup_menu( $menu ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by OptionsKit filter.
 		return array(
 			'parent'     => 'users.php',
 			'page_title' => __( 'WP User Manager Settings', 'wp-user-manager' ),
@@ -111,7 +111,7 @@ class WPUM_Options_Panel {
 	 *
 	 * @return array
 	 */
-	public function register_settings_subsections( $sections ) {
+	public function register_settings_subsections( $sections ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by OptionsKit filter.
 		return array(
 			'general'      => array(
 				'login' => __( 'Login Settings', 'wp-user-manager' ),

--- a/includes/class-wp-user-manager.php
+++ b/includes/class-wp-user-manager.php
@@ -229,7 +229,7 @@ if ( ! class_exists( 'WP_User_Manager' ) ) :
 		 *
 		 * @return void
 		 */
-		public function ensure_addon_class_alias( $class ) {
+		public function ensure_addon_class_alias( $class ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.classFound -- Matches spl_autoload_register callback signature.
 			if ( strpos( $class, 'WPUM\\' ) === 0 ) {
 				// Class is already scoped
 				return;
@@ -276,7 +276,7 @@ if ( ! class_exists( 'WP_User_Manager' ) ) :
 		 *
 		 * @return void
 		 */
-		public function ensure_class_alias( $class ) {
+		public function ensure_class_alias( $class ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.classFound -- Matches spl_autoload_register callback signature.
 			// If the namespace beings with the dependency class prefix, make an alias for regular class.
 			if ( strpos( $class, 'WPUM' ) !== 0 ) {
 				return;

--- a/includes/emails/wpum-email-functions.php
+++ b/includes/emails/wpum-email-functions.php
@@ -44,7 +44,7 @@ function wpum_get_emails_tags_list() {
  *
  * @return string
  */
-function wpum_email_tag_website( $user_id ) {
+function wpum_email_tag_website( $user_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by email tag callback signature.
 	return home_url();
 }
 
@@ -55,7 +55,7 @@ function wpum_email_tag_website( $user_id ) {
  *
  * @return string
  */
-function wpum_email_tag_sitename( $user_id ) {
+function wpum_email_tag_sitename( $user_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by email tag callback signature.
 	return esc_html( get_bloginfo( 'name' ) );
 }
 
@@ -131,7 +131,7 @@ function wpum_email_tag_lastname( $user_id ) {
  *
  * @return string
  */
-function wpum_email_tag_login_page_url( $user_id = false ) {
+function wpum_email_tag_login_page_url( $user_id = false ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by email tag callback signature.
 
 	$login_page_url = wpum_get_core_page_id( 'login' );
 	$login_page_url = get_permalink( $login_page_url );

--- a/includes/fields/class-wpum-field-group.php
+++ b/includes/fields/class-wpum-field-group.php
@@ -87,7 +87,7 @@ class WPUM_Field_Group {
 		$this->db = new WPUM_DB_Fields_Groups();
 
 		if ( empty( $_id_or_group ) ) {
-			return false;
+			return;
 		}
 
 		if ( is_a( $_id_or_group, 'WPUM_Field_Group' ) ) {
@@ -100,7 +100,7 @@ class WPUM_Field_Group {
 		if ( $group ) {
 			$this->setup_field_group( $group );
 		} else {
-			return false;
+			return;
 		}
 	}
 

--- a/includes/fields/class-wpum-field.php
+++ b/includes/fields/class-wpum-field.php
@@ -143,7 +143,7 @@ class WPUM_Field {
 		$this->db = new WPUM_DB_Fields();
 
 		if ( empty( $_id_or_field ) ) {
-			return false;
+			return;
 		}
 
 		if ( is_a( $_id_or_field, 'WPUM_Field' ) ) {
@@ -156,7 +156,7 @@ class WPUM_Field {
 		if ( $field ) {
 			$this->setup_field( $field );
 		} else {
-			return false;
+			return;
 		}
 	}
 

--- a/includes/fields/class-wpum-fields-editor.php
+++ b/includes/fields/class-wpum-fields-editor.php
@@ -325,7 +325,7 @@ class WPUM_Fields_Editor {
 	 * @param int $group_id
 	 * @param int $parent
 	 */
-	protected function delete_group_fields_cache( $group_id, $parent = 0 ) {
+	protected function delete_group_fields_cache( $group_id, $parent = 0 ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.parentFound -- Public API, cannot rename.
 		$args = array(
 			'group_id' => (int) $group_id,
 			'orderby'  => 'field_order',

--- a/includes/fields/types/class-wpum-field-file.php
+++ b/includes/fields/types/class-wpum-field-file.php
@@ -89,7 +89,7 @@ class WPUM_Field_File extends WPUM_Field_Type {
 	 * @return  string|array
 	 */
 	protected function upload_file( $field_key, $field ) {
-		if ( ! empty( $_FILES[ $field_key ] ) && ! empty( $_FILES[ $field_key ]['name'] ) ) {
+		if ( ! empty( $_FILES[ $field_key ] ) && ! empty( $_FILES[ $field_key ]['name'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in parent form handler.
 			$allowed_mime_types = wpum_get_allowed_mime_types();
 			if ( ! empty( $field['allowed_mime_types'] ) ) {
 				$extensions         = explode( ',', $field['allowed_mime_types'] );
@@ -111,14 +111,14 @@ class WPUM_Field_File extends WPUM_Field_Type {
 				// translators: %s field label
 				$too_big_message = sprintf( esc_html__( 'The uploaded %s file is too big.', 'wp-user-manager' ), $field['label'] );
 				if ( defined( 'WPUM_MAX_AVATAR_SIZE' ) && 'user_avatar' === $field_key && $file_to_upload['size'] > WPUM_MAX_AVATAR_SIZE ) {
-					throw new Exception( $too_big_message );
+					throw new Exception( esc_html( $too_big_message ) );
 				}
 				if ( defined( 'WPUM_MAX_COVER_SIZE' ) && 'user_cover' === $field_key && $file_to_upload['size'] > WPUM_MAX_COVER_SIZE ) {
-					throw new Exception( $too_big_message );
+					throw new Exception( esc_html( $too_big_message ) );
 				}
 
 				if ( isset( $field['max_file_size'] ) && ! empty( $field['max_file_size'] ) && $file_to_upload['size'] > $field['max_file_size'] ) {
-					throw new Exception( $too_big_message );
+					throw new Exception( esc_html( $too_big_message ) );
 				}
 
 				$uploaded_file = wpum_upload_file( $file_to_upload, array(
@@ -128,7 +128,7 @@ class WPUM_Field_File extends WPUM_Field_Type {
 				) );
 
 				if ( is_wp_error( $uploaded_file ) ) {
-					throw new Exception( $uploaded_file->get_error_message() );
+					throw new Exception( esc_html( $uploaded_file->get_error_message() ) );
 				} else {
 					$file_urls[] = array(
 						'url'  => $uploaded_file->url,

--- a/includes/fields/types/class-wpum-field-repeater.php
+++ b/includes/fields/types/class-wpum-field-repeater.php
@@ -218,11 +218,11 @@ class WPUM_Field_Repeater extends WPUM_Field_Type {
 
 		$posted = isset( $_POST[ $key ] ) ? $this->sanitize_posted_field( $_POST[ $key ], $field['sanitizer'] ) : array(); // phpcs:ignore
 
-		if ( ! isset( $_FILES[ $key ] ) ) {
+		if ( ! isset( $_FILES[ $key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in parent form handler.
 			return $posted;
 		}
 
-		if ( isset( $_FILES[ $key ] ) && ! empty( $_FILES[ $key ] ) ) {
+		if ( isset( $_FILES[ $key ] ) && ! empty( $_FILES[ $key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in parent form handler.
 			$files = $this->upload_file( $key, $field );
 		}
 
@@ -251,7 +251,7 @@ class WPUM_Field_Repeater extends WPUM_Field_Type {
 	 * @return  string|array
 	 */
 	protected function upload_file( $field_key, $field ) {
-		if ( isset( $_FILES[ $field_key ] ) && ! empty( $_FILES[ $field_key ] ) ) {
+		if ( isset( $_FILES[ $field_key ] ) && ! empty( $_FILES[ $field_key ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verified in parent form handler.
 			$allowed_mime_types = wpum_get_allowed_mime_types();
 			$files              = array();
 
@@ -298,7 +298,7 @@ class WPUM_Field_Repeater extends WPUM_Field_Type {
 					$too_big_message = sprintf( esc_html__( 'The uploaded %s file is too big.', 'wp-user-manager' ), $field_name );
 
 					if ( ! empty( $field_max_size ) && $file_to_upload['size'] > $field_max_size ) {
-						throw new Exception( $too_big_message );
+						throw new Exception( esc_html( $too_big_message ) );
 					}
 
 					$uploaded_file = wpum_upload_file( $file_to_upload, array(
@@ -308,7 +308,7 @@ class WPUM_Field_Repeater extends WPUM_Field_Type {
 					) );
 
 					if ( is_wp_error( $uploaded_file ) ) {
-						throw new Exception( $uploaded_file->get_error_message() );
+						throw new Exception( esc_html( $uploaded_file->get_error_message() ) );
 					} else {
 						$file_urls[ $cloned_keys[ $field_key ] ][ $primary_key ] = $uploaded_file->url;
 					}

--- a/includes/fields/wpum-fields-functions.php
+++ b/includes/fields/wpum-fields-functions.php
@@ -513,7 +513,7 @@ function wpum_get_field_type() {
  * @param  string $class custom class to add to the field.
  * @return array        list of all classes.
  */
-function wpum_get_field_css_class( $class = false ) {
+function wpum_get_field_css_class( $class = false ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.classFound -- Public API, cannot rename.
 
 	global $wpum_profile_fields;
 
@@ -542,7 +542,7 @@ function wpum_get_field_css_class( $class = false ) {
  * @param  string $class custom class to add to the fields.
  * @return void
  */
-function wpum_the_field_css_class( $class = false ) {
+function wpum_the_field_css_class( $class = false ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.classFound -- Public API, cannot rename.
 	echo esc_attr( join( ' ', wpum_get_field_css_class( $class ) ) );
 }
 

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -77,7 +77,7 @@ add_filter( 'register_url', 'wpum_set_registration_url' );
  *
  * @return string
  */
-function wpum_set_lostpassword_url( $url, $redirect ) {
+function wpum_set_lostpassword_url( $url, $redirect ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress hook signature.
 
 	$password_page = wpum_get_core_page_id( 'password' );
 
@@ -122,7 +122,7 @@ add_filter( 'logout_url', 'wpum_set_logout_url', 20, 2 );
  *
  * @return string
  */
-function wpum_login_url( $login_url, $redirect, $force_reauth ) {
+function wpum_login_url( $login_url, $redirect, $force_reauth ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress hook signature.
 
 	$wpum_login_page = wpum_get_core_page_id( 'login' );
 	$wpum_login_page = get_permalink( $wpum_login_page );
@@ -149,7 +149,7 @@ if ( wpum_get_option( 'lock_wplogin' ) || wpum_get_option( 'lock_complete_site' 
 function wpum_authentication( $wp_user, $username, $password ) {
 
 	// Skip authentication method for admin users
-	if ( ! is_wp_error( $wp_user ) && ( apply_filters( 'wpum_authentication_method_admin_override', true ) && user_can( $wp_user, 'administrator' ) ) ) {
+	if ( ! is_wp_error( $wp_user ) && ( apply_filters( 'wpum_authentication_method_admin_override', true ) && user_can( $wp_user, 'manage_options' ) ) ) {
 		return $wp_user;
 	}
 

--- a/includes/forms/class-wpum-form-password-recovery.php
+++ b/includes/forms/class-wpum-form-password-recovery.php
@@ -163,7 +163,7 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 
 		if ( 'password-recovery' === $form && isset( $values['user']['username_email'] ) ) {
 			$username = sanitize_text_field( $values['user']['username_email'] );
-			if ( is_email( $username ) && ! email_exists( $username ) || ! is_email( $username ) && ! username_exists( $username ) ) {
+			if ( ( is_email( $username ) && ! email_exists( $username ) ) || ( ! is_email( $username ) && ! username_exists( $username ) ) ) {
 				return new WP_Error( 'username-validation-error', esc_html__( 'A user with this username or email does not exist. Please check your entry and try again.', 'wp-user-manager' ) );
 			}
 		}

--- a/includes/forms/class-wpum-registration-form.php
+++ b/includes/forms/class-wpum-registration-form.php
@@ -76,7 +76,7 @@ class WPUM_Registration_Form {
 		$this->db = new WPUM_DB_Registration_Forms();
 
 		if ( empty( $_id_or_form ) ) {
-			return false;
+			return;
 		}
 
 		if ( is_a( $_id_or_form, 'WPUM_DB_Registration_Forms' ) ) {
@@ -89,7 +89,7 @@ class WPUM_Registration_Form {
 		if ( $form ) {
 			$this->setup_form( $form );
 		} else {
-			return false;
+			return;
 		}
 	}
 
@@ -334,7 +334,7 @@ class WPUM_Registration_Form {
 	 *
 	 * @return mixed
 	 */
-	public function get_setting( $key, $default = false ) {
+	public function get_setting( $key, $default = false ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound -- Public API, cannot rename.
 		$form_setting = $this->get_meta( $key );
 
 		if ( false !== $form_setting ) {
@@ -399,7 +399,7 @@ class WPUM_Registration_Form {
 	 * @access  public
 	 * @since   2.0
 	 */
-	public function delete_meta( $meta_key, $meta_value, $prev_value = '' ) {
+	public function delete_meta( $meta_key, $meta_value, $prev_value = '' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Matches WordPress meta API signature.
 		return WPUM()->registration_form_meta->delete_meta( $this->id, $meta_key, $meta_value );
 	}
 

--- a/includes/forms/trait-wpum-account.php
+++ b/includes/forms/trait-wpum-account.php
@@ -63,7 +63,7 @@ trait WPUM_Form_Account {
 		$updated_user_id = wp_update_user( $user_data );
 
 		if ( is_wp_error( $updated_user_id ) ) {
-			throw new Exception( $updated_user_id->get_error_message() );
+			throw new Exception( esc_html( $updated_user_id->get_error_message() ) );
 		}
 
 		$upload_dir = wp_upload_dir();
@@ -75,7 +75,7 @@ trait WPUM_Form_Account {
 			$existing_avatar_file_path = get_user_meta( $updated_user_id, '_current_user_avatar_path', true );
 
 			if ( $existing_avatar_file_path && strpos( realpath( $existing_avatar_file_path ), $upload_dir ) !== 0 ) {
-				throw new Exception( __( 'Path error with existing avatar', 'wp-user-manager' ) );
+				throw new Exception( esc_html__( 'Path error with existing avatar', 'wp-user-manager' ) );
 			}
 
 			// Delete previous avatar if a new one has been uploaded.
@@ -104,7 +104,7 @@ trait WPUM_Form_Account {
 		$existing_cover_file_path = get_user_meta( $updated_user_id, '_user_cover_path', true );
 
 		if ( $existing_cover_file_path && strpos( realpath( $existing_cover_file_path ), $upload_dir ) !== 0 ) {
-			throw new Exception( __( 'Path error with existing cover', 'wp-user-manager' ) );
+			throw new Exception( esc_html__( 'Path error with existing cover', 'wp-user-manager' ) );
 		}
 
 		if ( isset( $values['account']['user_cover']['url'] ) ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -186,7 +186,7 @@ function wpum_get_core_page_id( $page = null ) {
  *               corresponding to `$index_key`. If `$index_key` is null, array keys from the original
  *               `$list` will be preserved in the results.
  */
-function wpum_list_pluck( $list, $field, $index_key = null ) {
+function wpum_list_pluck( $list, $field, $index_key = null ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.listFound -- Public API, cannot rename.
 	if ( ! $index_key ) {
 		/**
 		 * This is simple. Could at some point wrap array_column()
@@ -1273,7 +1273,7 @@ if ( ! function_exists( 'wp_new_user_notification' ) ) {
 	 *
 	 * @return void
 	 */
-	function wp_new_user_notification( $user_id, $plaintext_pass = '' ) {
+	function wp_new_user_notification( $user_id, $plaintext_pass = '' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Matches WordPress core function signature.
 
 		$password_set_by_admin = false;
 		if ( isset( $_POST['pass1-text'] ) ) { // phpcs:ignore

--- a/includes/integrations/elementor/class-wpum-elementor-loader.php
+++ b/includes/integrations/elementor/class-wpum-elementor-loader.php
@@ -77,7 +77,7 @@ class WPUM_Elementor_Loader {
 	 * @param Widgets_Manager $widgets
 	 */
 	public function wpum_register_elementor_widets( $widgets ) {
-		spl_autoload_register( function ( $class ) {
+		spl_autoload_register( function ( $class ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.classFound -- Matches spl_autoload_register signature.
 			$file = 'extensions/class-' . str_replace( '_', '-', strtolower( $class ) ) . '.php';
 			if ( file_exists( WPUM_PLUGIN_DIR . 'includes/integrations/elementor/' . $file ) ) {
 				include $file;
@@ -86,7 +86,7 @@ class WPUM_Elementor_Loader {
 
 		( new WPUM_RestrictionControls() )::get_instance();
 
-		spl_autoload_register( function ( $class ) {
+		spl_autoload_register( function ( $class ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.classFound -- Matches spl_autoload_register signature.
 			$file = 'widgets/class-' . str_replace( '_', '-', strtolower( $class ) ) . '.php';
 			if ( file_exists( WPUM_PLUGIN_DIR . 'includes/integrations/elementor/' . $file ) ) {
 				include $file;

--- a/includes/integrations/stripe/Account.php
+++ b/includes/integrations/stripe/Account.php
@@ -81,7 +81,7 @@ class Account {
 	 * Redirect users who aren't subscribed or paid
 	 */
 	public function unsubscribed_redirect() {
-		if ( ! is_user_logged_in() || current_user_can( 'administrator' ) ) {
+		if ( ! is_user_logged_in() || current_user_can( 'manage_options' ) ) {
 			return;
 		}
 

--- a/includes/options.php
+++ b/includes/options.php
@@ -33,7 +33,7 @@ function wpum_get_settings() {
  *
  * @return mixed
  */
-function wpum_get_option( $key = '', $default = false ) {
+function wpum_get_option( $key = '', $default = false ) { // phpcs:ignore Universal.NamingConventions.NoReservedKeywordParameterNames.defaultFound -- Public API, cannot rename.
 	global $wpum_options;
 	$value = ! empty( $wpum_options[ $key ] ) ? $wpum_options[ $key ] : $default;
 	$value = apply_filters( 'wpum_get_option', $value, $key, $default );

--- a/includes/shortcodes/shortcodes.php
+++ b/includes/shortcodes/shortcodes.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @return array
  */
-function wpum_login_form( $atts, $content = null ) {
+function wpum_login_form( $atts, $content = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress shortcode callback signature.
 
 	extract( // phpcs:ignore
 		shortcode_atts(
@@ -61,7 +61,7 @@ add_shortcode( 'wpum_login_form', 'wpum_login_form' );
  *
  * @return string
  */
-function wpum_password_recovery( $atts, $content = null ) {
+function wpum_password_recovery( $atts, $content = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress shortcode callback signature.
 
 	extract( // phpcs:ignore
 		shortcode_atts(
@@ -96,7 +96,7 @@ add_shortcode( 'wpum_password_recovery', 'wpum_password_recovery' );
  *
  * @return string
  */
-function wpum_login_link( $atts, $content = null ) {
+function wpum_login_link( $atts, $content = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress shortcode callback signature.
 
 	$args = shortcode_atts(
 		array(
@@ -139,7 +139,7 @@ add_shortcode( 'wpum_login', 'wpum_login_link' );
  *
  * @return string
  */
-function wpum_logout_link( $atts, $content = null ) {
+function wpum_logout_link( $atts, $content = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress shortcode callback signature.
 
 	$args = shortcode_atts(
 		array(
@@ -167,7 +167,7 @@ add_shortcode( 'wpum_logout', 'wpum_logout_link' );
  *
  * @return string
  */
-function wpum_registration_form( $atts, $content = null ) {
+function wpum_registration_form( $atts, $content = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress shortcode callback signature.
 
 	extract( // phpcs:ignore
 		shortcode_atts(
@@ -237,7 +237,7 @@ add_shortcode( 'wpum_register', 'wpum_registration_form' );
  *
  * @return string
  */
-function wpum_account_page( $atts, $content = null ) {
+function wpum_account_page( $atts, $content = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress shortcode callback signature.
 
 	ob_start();
 
@@ -259,7 +259,7 @@ add_shortcode( 'wpum_account', 'wpum_account_page' );
  *
  * @return string
  */
-function wpum_profile( $atts, $content = null ) {
+function wpum_profile( $atts, $content = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress shortcode callback signature.
 
 	ob_start();
 
@@ -306,7 +306,7 @@ function wpum_profile( $atts, $content = null ) {
 			)
 			->get_template_part( 'messages/general', 'warning' );
 
-	} elseif ( is_user_logged_in() && $queried_user_id && ! wpum_members_can_view_profiles( $queried_user_id ) && ! wpum_is_own_profile() && ! current_user_can( 'administrator' ) ) {
+	} elseif ( is_user_logged_in() && $queried_user_id && ! wpum_members_can_view_profiles( $queried_user_id ) && ! wpum_is_own_profile() && ! current_user_can( 'manage_options' ) ) {
 
 		WPUM()->templates
 			->set_template_data(
@@ -623,7 +623,7 @@ add_shortcode( 'wpum_restrict_to_user_roles', 'wpum_restrict_to_user_roles' );
  *
  * @return string
  */
-function wpum_recently_registered( $atts, $content = null ) {
+function wpum_recently_registered( $atts, $content = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress shortcode callback signature.
 
 	extract( // phpcs:ignore
 		shortcode_atts(
@@ -660,7 +660,7 @@ add_shortcode( 'wpum_recently_registered', 'wpum_recently_registered' );
  *
  * @return string
  */
-function wpum_profile_card( $atts, $content = null ) {
+function wpum_profile_card( $atts, $content = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress shortcode callback signature.
 
 	extract( // phpcs:ignore
 		shortcode_atts(
@@ -714,7 +714,7 @@ add_shortcode( 'wpum_profile_card', 'wpum_profile_card' );
  *
  * @return string
  */
-function wpum_directory( $atts, $content = null ) {
+function wpum_directory( $atts, $content = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by WordPress shortcode callback signature.
 
 	extract( // phpcs:ignore
 		shortcode_atts(

--- a/includes/updates/class-wpum-license.php
+++ b/includes/updates/class-wpum-license.php
@@ -425,7 +425,7 @@ class WPUM_License {
 	 * @param array  $plugin_data
 	 * @param string $status
 	 */
-	public function plugin_page_notices( $plugin_file, $plugin_data, $status ) {
+	public function plugin_page_notices( $plugin_file, $plugin_data, $status ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by after_plugin_row hook.
 		$has_update = isset( $plugin_data['new_version'] ) && version_compare( $plugin_data['Version'], $plugin_data['new_version'] ) === -1;
 
 		$license_data   = $this->get_license_data();
@@ -500,7 +500,7 @@ class WPUM_License {
 	 * @param array $plugin_data
 	 * @param array $response
 	 */
-	public function in_plugin_update_message( $plugin_data, $response ) {
+	public function in_plugin_update_message( $plugin_data, $response ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by in_plugin_update_message hook.
 		$message = '';
 		if ( empty( $this->license ) ) {
 			// translators: %1$s licenses page URL


### PR DESCRIPTION
## Summary
- Resolves all 25 errors and 50 warnings from WPCS 3.x across 23 files
- PHPCS now passes with **zero errors and zero warnings**
- PHPStan also confirmed passing with zero errors

### Error fixes:
- **Capabilities vs roles**: Replaced `'administrator'` role checks with `'manage_options'` capability checks in 6 locations (filters.php, actions.php, class-wpum-menus.php, shortcodes.php, stripe/Account.php)
- **Boolean operator precedence**: Added parentheses to mixed `&&`/`||` expressions in password recovery and addons page
- **Escape output in exceptions**: Added `esc_html()` / `esc_html__()` to exception messages in trait-wpum-account.php, class-wpum-field-file.php, class-wpum-field-repeater.php
- **Nonce verification**: Added phpcs:ignore for `$_FILES` access in file upload handlers where nonces are verified by the parent form

### Warning fixes:
- **Constructor returns**: Changed `return false;` to `return;` in constructors (WPUM_Registration_Form, WPUM_Field_Group, WPUM_Field) — constructors cannot return values in PHP
- **Reserved keyword parameters**: Suppressed for public API functions that use `$class`, `$default`, `$list`, `$parent` (cannot rename without breaking backwards compatibility)
- **Unused function parameters**: Suppressed for WordPress hook callbacks that must accept parameters by position (shortcodes, filters, actions)

## Test plan
- [x] PHPCS passes with zero errors and zero warnings
- [x] PHPStan passes with zero errors
- [x] CI passes (PHPCS, PHPStan, WPUnit)
- [ ] Verify admin dashboard access restriction still works (`manage_options` instead of `administrator`)
- [ ] Verify Stripe billing redirect still bypasses for admins
- [ ] Verify menu visibility restrictions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)