### PR TITLE
Update brain/cortex to fix PHP 8.3 deprecation warnings

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,24 +12,27 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Brain-WP/Cortex.git",
-                "reference": "dd6484cd8b049a141b5a73746857fa5415caaca4"
+                "reference": "86bec053ec2c4d2e4c75af64e0cee951d9b0054b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Brain-WP/Cortex/zipball/dd6484cd8b049a141b5a73746857fa5415caaca4",
-                "reference": "dd6484cd8b049a141b5a73746857fa5415caaca4",
+                "url": "https://api.github.com/repos/Brain-WP/Cortex/zipball/86bec053ec2c4d2e4c75af64e0cee951d9b0054b",
+                "reference": "86bec053ec2c4d2e4c75af64e0cee951d9b0054b",
                 "shasum": ""
             },
             "require": {
                 "nikic/fast-route": "~0.7.0",
                 "php": ">=5.5",
-                "psr/http-message": "*"
+                "psr/http-message": "<1.1"
             },
             "require-dev": {
                 "brain/monkey": "~1.2.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "gmazzap/andrew": "~1.0.0",
                 "mockery/mockery": "0.9.3",
-                "phpunit/phpunit": "4.8.*"
+                "phpcompatibility/php-compatibility": "^9.3",
+                "phpunit/phpunit": "4.8.*",
+                "squizlabs/php_codesniffer": "^3.7"
             },
             "default-branch": true,
             "type": "library",
@@ -64,7 +67,7 @@
                 "issues": "https://github.com/Brain-WP/Cortex/issues",
                 "source": "https://github.com/Brain-WP/Cortex"
             },
-            "time": "2022-08-12T12:11:36+00:00"
+            "time": "2023-09-18T08:17:56+00:00"
         },
         {
             "name": "composer/installers",


### PR DESCRIPTION
## Summary
- Updates `brain/cortex` from `dd6484c` (Aug 2022) to `86bec05` (Sept 2023)
- The newer version adds `#[\ReturnTypeWillChange]` attributes to `Iterator`, `ArrayAccess`, `Countable` and `FilterIterator` method implementations
- This should resolve the PHP 8.3 deprecation warnings reported in the frontend

Fixes #418

## Test plan
- [ ] Enable `WP_DEBUG` and `WP_DEBUG_LOG` on PHP 8.3
- [ ] Visit a user profile page on the frontend
- [ ] Confirm no `Brain\Cortex` deprecation warnings in the debug log
- [ ] Run the build to verify vendor-dist is regenerated correctly with the attributes intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)