### PR TITLE
Fix: password recovery when username is an email differing from stored email

### DIFF
--- a/includes/fields/class-wpum-field.php
+++ b/includes/fields/class-wpum-field.php
@@ -218,11 +218,11 @@ class WPUM_Field {
 
 		if ( ! empty( $this->id ) ) {
 
-			$this->is_primary    = $this->set_as_primary_field( $this->type );
-			$this->required      = $this->get_meta( 'required' );
-			$this->visibility    = $this->get_meta( 'visibility' );
-			$this->editable      = $this->get_meta( 'editing' );
-			$this->parent_id     = max( 0, (int) $this->get_meta( 'parent_id' ) );
+			$this->is_primary = $this->set_as_primary_field( $this->type );
+			$this->required   = $this->get_meta( 'required' );
+			$this->visibility = $this->get_meta( 'visibility' );
+			$this->editable   = $this->get_meta( 'editing' );
+			$this->parent_id  = max( 0, (int) $this->get_meta( 'parent_id' ) );
 
 			$class = 'WPUM_Field_' . ucfirst( $this->get_type() );
 			if ( class_exists( $class ) ) {

--- a/includes/forms/class-wpum-form-password-recovery.php
+++ b/includes/forms/class-wpum-form-password-recovery.php
@@ -161,11 +161,13 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 	 */
 	public function validate_username_or_email( $pass, $fields, $values, $form ) {
 
-		if ( 'password-recovery' === $form && isset( $values['user']['username_email'] ) ) {
-			$username = sanitize_text_field( $values['user']['username_email'] );
-			if ( ( is_email( $username ) && ! email_exists( $username ) ) || ( ! is_email( $username ) && ! username_exists( $username ) ) ) {
-				return new WP_Error( 'username-validation-error', esc_html__( 'A user with this username or email does not exist. Please check your entry and try again.', 'wp-user-manager' ) );
-			}
+		if ( $form !== 'password-recovery' || ! isset( $values['user']['username_email'] ) ) {
+			return $pass;
+		}
+
+		$username = sanitize_text_field( $values['user']['username_email'] );
+		if ( ! email_exists( $values['user']['username_email'] ) && ! username_exists( $values['user']['username_email'] ) ) {
+			return new WP_Error( 'username-validation-error', esc_html__( 'A user with this username or email does not exist. Please check your entry and try again.', 'wp-user-manager' ) );
 		}
 
 		return $pass;
@@ -229,10 +231,10 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 			$username = $values['user']['username_email'];
 			$user     = false;
 
-			// Retrieve the user from the DB.
-			if ( is_email( $username ) ) {
-				$user = get_user_by( 'email', $username );
-			} else {
+			// Retrieve the user from the DB. Try email first, then fall back to username.
+			$user = get_user_by( 'email', $username );
+
+			if ( ! $user instanceof WP_User ) {
 				$user = get_user_by( 'login', $username );
 			}
 
@@ -283,9 +285,10 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 
 		$username = $values['user']['username_email'];
 
-		if ( is_email( $username ) ) {
-			$user = get_user_by( 'email', $username );
-		} else {
+		// Retrieve the user from the DB. Try email first, then fall back to username.
+		$user = get_user_by( 'email', $username );
+
+		if ( ! $user instanceof WP_User ) {
 			$user = get_user_by( 'login', $username );
 		}
 

--- a/includes/forms/class-wpum-form-password-recovery.php
+++ b/includes/forms/class-wpum-form-password-recovery.php
@@ -161,7 +161,7 @@ class WPUM_Form_Password_Recovery extends WPUM_Form {
 	 */
 	public function validate_username_or_email( $pass, $fields, $values, $form ) {
 
-		if ( $form !== 'password-recovery' || ! isset( $values['user']['username_email'] ) ) {
+		if ( 'password-recovery' !== $form || ! isset( $values['user']['username_email'] ) ) {
 			return $pass;
 		}
 

--- a/tests/e2e/password-recovery.spec.ts
+++ b/tests/e2e/password-recovery.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect, wpCli } from './fixtures';
 
 test.describe('Password Recovery Form', () => {
   test.beforeEach(async ({ page }) => {
@@ -80,5 +80,33 @@ test.describe('Password Recovery Form', () => {
     // The form should still be visible for the user to try again
     const form = page.locator('.wpum-password-recovery-form');
     await expect(form).toBeVisible();
+  });
+
+  test('submitting login-style username that looks like an email shows success', async ({
+    page,
+    passwordRecoveryPage,
+  }) => {
+    // Regression test for #188: user whose login is an email-format string but
+    // differs from their stored email address should be able to recover password.
+    const suffix = Date.now();
+    const userLogin = `rectest${suffix}@olddomain.com`;
+    const userEmail = `rectest${suffix}@newdomain.com`;
+
+    wpCli(`user create "${userLogin}" "${userEmail}" --user_pass="StrongP@ss1!" --role="subscriber"`);
+
+    await page.goto(passwordRecoveryPage);
+
+    // Submit the login (which looks like an email) — NOT the stored email address.
+    await page.locator('#username_email').fill(userLogin);
+    await page.locator('input[name="submit_password_recovery"]').click();
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+
+    // Should show success, not an error saying the user doesn't exist.
+    const successMessage = page.locator('.wpum-password-reset-request-success');
+    await expect(successMessage).toBeVisible({ timeout: 10000 });
+    await expect(successMessage).toContainText('sent an email');
+
+    // Cleanup.
+    wpCli(`user delete "${userLogin}" --yes`);
   });
 });

--- a/tests/wpunit/PasswordRecovery/PasswordRecoverySubmitTest.php
+++ b/tests/wpunit/PasswordRecovery/PasswordRecoverySubmitTest.php
@@ -156,4 +156,77 @@ class PasswordRecoverySubmitTest extends PasswordRecoveryTestCase {
 
 		$this->assertArrayHasKey( 'username_email', $fields, 'Should have username_email field.' );
 	}
+
+	/**
+	 * Regression test for #188: user whose login looks like an email but differs
+	 * from their stored email should still pass validate_username_or_email().
+	 */
+	public function test_email_as_username_passes_when_differs_from_stored_email() {
+		$this->factory()->user->create( array(
+			'user_login' => 'john_' . wp_rand() . '@olddomain.com',
+			'user_pass'  => 'StrongP@ss1!',
+			'user_email' => 'john_' . wp_rand() . '@newdomain.com',
+		) );
+
+		// We need a deterministic login/email pair - recreate with fixed values via a unique suffix.
+		$suffix     = wp_rand( 1000, 9999 );
+		$user_login = 'user' . $suffix . '@olddomain.com';
+		$user_email = 'user' . $suffix . '@newdomain.com';
+
+		$this->factory()->user->create( array(
+			'user_login' => $user_login,
+			'user_pass'  => 'StrongP@ss1!',
+			'user_email' => $user_email,
+		) );
+
+		$form = \WPUM_Form_Password_Recovery::instance();
+
+		// Submit the login (which looks like an email) — NOT the stored email.
+		$result = $form->validate_username_or_email(
+			true,
+			array(),
+			array(
+				'user' => array(
+					'username_email' => $user_login,
+				),
+			),
+			'password-recovery'
+		);
+
+		$this->assertTrue(
+			$result,
+			'Validation should pass when the submitted value is a username that looks like an email, even if it differs from the stored email.'
+		);
+	}
+
+	/**
+	 * Regression test for #188: submitting the stored email (not the login) should also pass.
+	 */
+	public function test_stored_email_passes_when_login_is_different_email_format() {
+		$suffix     = wp_rand( 1000, 9999 );
+		$user_login = 'loginuser' . $suffix . '@olddomain.com';
+		$user_email = 'loginuser' . $suffix . '@newdomain.com';
+
+		$this->factory()->user->create( array(
+			'user_login' => $user_login,
+			'user_pass'  => 'StrongP@ss1!',
+			'user_email' => $user_email,
+		) );
+
+		$form = \WPUM_Form_Password_Recovery::instance();
+
+		// Submit the stored email address.
+		$result = $form->validate_username_or_email(
+			true,
+			array(),
+			array(
+				'user' => array(
+					'username_email' => $user_email,
+				),
+			),
+			'password-recovery'
+		);
+
+		$this->assertTrue( $result, 'Validation should pass when the submitted value is the stored email address.' );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #188 — password reset fails when a user's `user_login` is formatted as an email address but differs from their `user_email`.

**Bug scenario:** A user has `user_login = 'john@olddomain.com'` and `user_email = 'john@newdomain.com'`. When they attempt password recovery by entering their username (`john@olddomain.com`), the old validation logic calls `is_email()`, sees it looks like an email, then calls `email_exists()` which returns `false` (because the stored email is different). The valid username is therefore rejected with an error.

## Changes

Three changes made to `includes/forms/class-wpum-form-password-recovery.php`:

1. **`validate_username_or_email()`** — Replaced the `is_email()` branch with independent checks: `email_exists() || username_exists()`. Either match is sufficient to pass validation.

2. **`submit_handler()`** — Always try `get_user_by('email')` first, then fall back to `get_user_by('login')` if no user is found. This covers the case where the submitted value matches as a login even though it looks like an email.

3. **`instructions_sent()`** — Same email-first, login-fallback lookup applied for consistency.

## Tests

Two regression tests added to `tests/wpunit/PasswordRecovery/PasswordRecoverySubmitTest.php`:

- `test_email_as_username_passes_when_differs_from_stored_email` — verifies a login that looks like an email (but differs from stored email) passes validation
- `test_stored_email_passes_when_login_is_different_email_format` — verifies the stored email address also passes in the same scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)