### PR TITLE
Security: validate profile and account tab input

### DIFF
--- a/includes/actions.php
+++ b/includes/actions.php
@@ -262,10 +262,11 @@ add_action( 'template_redirect', 'wpum_restrict_account_page' );
  */
 function wpum_display_account_page_content() {
 
-	$active_tab = get_query_var( 'tab' );
 	$tabs       = wpum_get_account_page_tabs();
+	$active_tab = get_query_var( 'tab' );
 
-	if ( empty( $active_tab ) ) {
+	// Validate against registered tabs to prevent path traversal / LFI.
+	if ( empty( $active_tab ) || ! isset( $tabs[ $active_tab ] ) ) {
 		$active_tab = key( $tabs );
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -951,8 +951,14 @@ function wpum_get_profile_tab_url( $user, $tab ) {
  * @return string
  */
 function wpum_get_active_profile_tab() {
-	$first_tab   = key( wpum_get_registered_profile_tabs() );
+	$registered  = wpum_get_registered_profile_tabs();
+	$first_tab   = key( $registered );
 	$profile_tab = get_query_var( 'tab', $first_tab );
+
+	// Validate against registered tabs to prevent path traversal / LFI.
+	if ( ! isset( $registered[ $profile_tab ] ) ) {
+		$profile_tab = $first_tab;
+	}
 
 	return $profile_tab;
 }

--- a/tests/wpunit/Profile/TabValidationTest.php
+++ b/tests/wpunit/Profile/TabValidationTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Tests for profile tab validation — ensures tab query var is validated
+ * against registered tabs to prevent path traversal / LFI.
+ */
+
+class TabValidationTest extends \Codeception\TestCase\WPTestCase {
+
+	public function _setUp() {
+		parent::_setUp();
+
+		if ( ! function_exists( 'wpum_get_active_profile_tab' ) ) {
+			require_once WPUM_PLUGIN_DIR . 'includes/functions.php';
+		}
+	}
+
+	public function _tearDown() {
+		set_query_var( 'tab', '' );
+		parent::_tearDown();
+	}
+
+	public function test_valid_tab_is_returned() {
+		set_query_var( 'tab', 'about' );
+		$this->assertEquals( 'about', wpum_get_active_profile_tab() );
+	}
+
+	public function test_valid_posts_tab_is_returned() {
+		// Enable posts tab.
+		wpum_update_option( 'profile_posts', true );
+		set_query_var( 'tab', 'posts' );
+		$this->assertEquals( 'posts', wpum_get_active_profile_tab() );
+	}
+
+	public function test_default_tab_when_no_query_var() {
+		set_query_var( 'tab', '' );
+		$tab = wpum_get_active_profile_tab();
+		$this->assertEquals( 'about', $tab );
+	}
+
+	public function test_traversal_tab_returns_default() {
+		set_query_var( 'tab', '../../wp-config' );
+		$tab = wpum_get_active_profile_tab();
+		$this->assertEquals( 'about', $tab );
+	}
+
+	public function test_dot_dot_slash_tab_returns_default() {
+		set_query_var( 'tab', '../../../etc/passwd' );
+		$tab = wpum_get_active_profile_tab();
+		$this->assertEquals( 'about', $tab );
+	}
+
+	public function test_unregistered_tab_returns_default() {
+		set_query_var( 'tab', 'nonexistent_tab_xyz' );
+		$tab = wpum_get_active_profile_tab();
+		$this->assertEquals( 'about', $tab );
+	}
+
+	public function test_null_byte_tab_returns_default() {
+		set_query_var( 'tab', "about\0../../wp-config" );
+		$tab = wpum_get_active_profile_tab();
+		$this->assertEquals( 'about', $tab );
+	}
+
+	public function test_backslash_tab_returns_default() {
+		set_query_var( 'tab', '..\\..\\wp-config' );
+		$tab = wpum_get_active_profile_tab();
+		$this->assertEquals( 'about', $tab );
+	}
+}


### PR DESCRIPTION
## Security Fix

Validates the `tab` query variable against the whitelist of registered tabs before using it in template loading or action hooks.

**Changes:**
- `wpum_get_active_profile_tab()` — validates tab against `wpum_get_registered_profile_tabs()`, falls back to default
- `wpum_display_account_page_content()` — validates tab against `wpum_get_account_page_tabs()`, falls back to default
- 8 WPUnit tests covering valid tabs, traversal attempts, null bytes, unregistered values

Patch for a responsibly disclosed vulnerability report (thanks to Yat via Wordfence).