### PR TITLE
Add generic login errors setting to prevent username enumeration

### DIFF
--- a/includes/admin/class-wpum-options-panel.php
+++ b/includes/admin/class-wpum-options-panel.php
@@ -246,7 +246,7 @@ class WPUM_Options_Panel {
 				),
 				array(
 					'id'   => 'generic_login_errors',
-					'name' => __( 'Generic Login Errors', 'wp-user-manager' ),
+					'name' => __( 'Generic Login Error', 'wp-user-manager' ),
 					'desc' => __( 'Replace specific login error messages with a generic message to prevent username enumeration.', 'wp-user-manager' ),
 					'type' => 'checkbox',
 				),

--- a/includes/admin/class-wpum-options-panel.php
+++ b/includes/admin/class-wpum-options-panel.php
@@ -244,6 +244,12 @@ class WPUM_Options_Panel {
 						'value' => true,
 					),
 				),
+				array(
+					'id'   => 'generic_login_errors',
+					'name' => __( 'Generic Login Errors', 'wp-user-manager' ),
+					'desc' => __( 'Replace specific login error messages with a generic message to prevent username enumeration.', 'wp-user-manager' ),
+					'type' => 'checkbox',
+				),
 			),
 			'misc'                 => array(
 				array(

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -183,6 +183,45 @@ function wpum_authentication( $wp_user, $username, $password ) {
 add_filter( 'authenticate', 'wpum_authentication', 20, 3 );
 
 /**
+ * Replace specific login error messages with a generic message
+ * to prevent username enumeration when the setting is enabled.
+ *
+ * @param WP_User|WP_Error $user
+ * @param string           $username
+ * @param string           $password
+ *
+ * @return WP_User|WP_Error
+ */
+function wpum_generic_login_errors( $user, $username, $password ) {
+	if ( ! is_wp_error( $user ) || empty( $username ) ) {
+		return $user;
+	}
+
+	if ( ! wpum_get_option( 'generic_login_errors' ) ) {
+		return $user;
+	}
+
+	$code = $user->get_error_code();
+
+	$enumeration_codes = array(
+		'invalid_username',
+		'invalid_email',
+		'incorrect_password',
+		'email_only',
+	);
+
+	if ( in_array( $code, $enumeration_codes, true ) ) {
+		return new WP_Error(
+			'authentication_failed',
+			__( '<strong>Error:</strong> The username or password you entered is incorrect.', 'wp-user-manager' )
+		);
+	}
+
+	return $user;
+}
+add_filter( 'authenticate', 'wpum_generic_login_errors', 50, 3 );
+
+/**
  * Highlight all pages used by WPUM.
  *
  * @param array  $post_states

--- a/includes/filters.php
+++ b/includes/filters.php
@@ -213,7 +213,7 @@ function wpum_generic_login_errors( $user, $username, $password ) {
 	if ( in_array( $code, $enumeration_codes, true ) ) {
 		return new WP_Error(
 			'authentication_failed',
-			__( '<strong>Error:</strong> The username or password you entered is incorrect.', 'wp-user-manager' )
+			apply_filters( 'wpum_generic_login_error_message', __( '<strong>Error:</strong> The username or password you entered is incorrect.', 'wp-user-manager' ) )
 		);
 	}
 

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from './fixtures';
+import { test, expect, wpCli } from './fixtures';
 
 test.describe('Login Form', () => {
   test.beforeEach(async ({ page }) => {
@@ -106,6 +106,37 @@ test.describe('Login Form', () => {
     // Verify we are NOT logged in
     await page.goto('/wp-admin/');
     await expect(page).toHaveURL(/wp-login\.php/);
+  });
+
+  test('generic login errors hides username enumeration', async ({ page, loginPage }) => {
+    wpCli(`eval 'wpum_update_option("generic_login_errors", true);'`);
+
+    await page.goto(loginPage);
+    await page.locator('#username').fill('nonexistent_user_12345');
+    await page.locator('#password').fill('WrongPassword123!');
+    await page.locator('input[name="submit_login"]').click();
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+
+    const errorMessage = page.locator('.wpum-message.error');
+    await expect(errorMessage).toBeVisible({ timeout: 5000 });
+    const errorText = await errorMessage.textContent();
+    expect(errorText).toContain('username or password you entered is incorrect');
+    expect(errorText).not.toContain('not registered');
+    expect(errorText).not.toContain('Unknown');
+
+    await page.goto(loginPage);
+    await page.locator('#username').fill('testuser_login');
+    await page.locator('#password').fill('WrongPassword123!');
+    await page.locator('input[name="submit_login"]').click();
+    await page.waitForLoadState('networkidle', { timeout: 10000 }).catch(() => {});
+
+    const errorMessage2 = page.locator('.wpum-message.error');
+    await expect(errorMessage2).toBeVisible({ timeout: 5000 });
+    const errorText2 = await errorMessage2.textContent();
+    expect(errorText2).toContain('username or password you entered is incorrect');
+    expect(errorText2).not.toContain('incorrect password');
+
+    wpCli(`eval 'wpum_update_option("generic_login_errors", false);'`);
   });
 
   test('redirect after login', async ({ page, loginPage }) => {


### PR DESCRIPTION
## Summary

- Adds a new **Generic Login Errors** checkbox under Settings → Login Settings
- When enabled, replaces specific login error messages (`invalid_username`, `incorrect_password`, `invalid_email`, `email_only`) with a single generic message: "The username or password you entered is incorrect"
- Prevents username enumeration via login error message differentiation
- Hooks into `authenticate` at priority 50 (after WPUM's own auth filter at 20 and WP core at 30)

## Test plan

- [ ] Enable the setting in WPUM → Settings → Login Settings → Generic Login Errors
- [ ] Try logging in with a non-existent username — error should say "username or password you entered is incorrect"
- [ ] Try logging in with a valid username but wrong password — same generic error
- [ ] Disable the setting — errors should revert to WordPress defaults (specific messages)
- [ ] E2E test covers both scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)