### PR TITLE
Fix PHP 8 fatal in avatar cache key when $id_or_email is an object

### DIFF
--- a/includes/admin/class-wpum-avatars.php
+++ b/includes/admin/class-wpum-avatars.php
@@ -204,7 +204,20 @@ class WPUM_Avatars {
 			return $url;
 		}
 
-		$cache_key = 'wpum_default_avatar_' . $id_or_email;
+		if ( is_object( $id_or_email ) ) {
+			if ( ! empty( $id_or_email->comment_ID ) ) {
+				$key_part = 'c' . $id_or_email->comment_ID;
+			} elseif ( ! empty( $id_or_email->ID ) ) {
+				$key_part = 'u' . $id_or_email->ID;
+			} elseif ( ! empty( $id_or_email->user_email ) ) {
+				$key_part = md5( $id_or_email->user_email );
+			} else {
+				$key_part = md5( wp_json_encode( $id_or_email ) );
+			}
+		} else {
+			$key_part = (string) $id_or_email;
+		}
+		$cache_key = 'wpum_default_avatar_' . $key_part;
 
 		$default_url = wpum_get_option( 'default_avatar_url' );
 		if ( empty( $default_url ) ) {


### PR DESCRIPTION
## Summary

- Fixes PHP 8 fatal error (`Object could not be converted to string`) in `WPUM_Avatars::set_default_avatar()` when `$id_or_email` is a `WP_Comment` or `WP_User` object
- Derives a safe scalar cache key from any input type: comment ID, user ID, email hash, or JSON hash fallback
- Affects any page with comments or author avatars rendered via `get_avatar()`

Fixes #443

## Test plan

- [ ] Visit a post with comments on PHP 8.0+ — should render without fatal
- [ ] Verify avatar caching still works (transient set/get with the new key format)
- [ ] Check Discussion settings page still works (admin early-return path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)